### PR TITLE
feat: add networking layer for API calls

### DIFF
--- a/FloraList/FloraList.xcodeproj/project.pbxproj
+++ b/FloraList/FloraList.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		CEE962F62DEF305B0002A40F /* Networking in Frameworks */ = {isa = PBXBuildFile; productRef = CEE962F52DEF305B0002A40F /* Networking */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		CE876C8B2DEE43E7000B9E5C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -27,6 +31,7 @@
 		CE876C792DEE43E4000B9E5C /* FloraList.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FloraList.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE876C8A2DEE43E7000B9E5C /* FloraListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FloraListTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE876C942DEE43E7000B9E5C /* FloraListUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FloraListUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CEE962F32DEF30340002A40F /* Networking */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Networking; path = ../Networking; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -52,6 +57,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CEE962F62DEF305B0002A40F /* Networking in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +84,8 @@
 				CE876C7B2DEE43E4000B9E5C /* FloraList */,
 				CE876C8D2DEE43E7000B9E5C /* FloraListTests */,
 				CE876C972DEE43E7000B9E5C /* FloraListUITests */,
+				CEE962F32DEF30340002A40F /* Networking */,
+				CEE962F42DEF305B0002A40F /* Frameworks */,
 				CE876C7A2DEE43E4000B9E5C /* Products */,
 			);
 			sourceTree = "<group>";
@@ -90,6 +98,13 @@
 				CE876C942DEE43E7000B9E5C /* FloraListUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		CEE962F42DEF305B0002A40F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -113,6 +128,7 @@
 			);
 			name = FloraList;
 			packageProductDependencies = (
+				CEE962F52DEF305B0002A40F /* Networking */,
 			);
 			productName = FloraList;
 			productReference = CE876C792DEE43E4000B9E5C /* FloraList.app */;
@@ -251,7 +267,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n    swiftlint || true\nelse\n    echo \"warning: SwiftLint not installed\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n    swiftlint || true\n    cd \"${SRCROOT}/Networking\" && swiftlint || true\nelse\n    echo \"warning: SwiftLint not installed\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -609,6 +625,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		CEE962F52DEF305B0002A40F /* Networking */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Networking;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = CE876C712DEE43E4000B9E5C /* Project object */;
 }

--- a/FloraList/FloraList.xcodeproj/project.pbxproj
+++ b/FloraList/FloraList.xcodeproj/project.pbxproj
@@ -34,9 +34,22 @@
 		CEE962F32DEF30340002A40F /* Networking */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Networking; path = ../Networking; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		CEE9631A2DEF38250002A40F /* Exceptions for "FloraList" folder in "FloraList" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = CE876C782DEE43E4000B9E5C /* FloraList */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		CE876C7B2DEE43E4000B9E5C /* FloraList */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				CEE9631A2DEF38250002A40F /* Exceptions for "FloraList" folder in "FloraList" target */,
+			);
 			path = FloraList;
 			sourceTree = "<group>";
 		};
@@ -435,6 +448,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = FloraList/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -473,6 +487,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = FloraList/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/FloraList/FloraList/Info.plist
+++ b/FloraList/FloraList/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>NSAppTransportSecurity</key>
+        <dict>
+            <key>NSExceptionDomains</key>
+            <dict>
+                <key>demo7677712.mockable.io</key>
+                <dict>
+                    <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                    <true/>
+                </dict>
+            </dict>
+        </dict>
+    </dict>
+</plist>

--- a/Networking/.gitignore
+++ b/Networking/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Networking/.swiftlint.yml
+++ b/Networking/.swiftlint.yml
@@ -1,0 +1,16 @@
+opt_in_rules:
+  - empty_count
+  - force_unwrapping
+  - closure_spacing
+  - collection_alignment
+
+disabled_rules:
+  - trailing_whitespace
+  - line_length
+
+excluded:
+  - .build
+  - Tests
+
+# Use the main project's config as parent for consistency
+parent_config: ../.swiftlint.yml 

--- a/Networking/Package.swift
+++ b/Networking/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Networking",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14),
+        .watchOS(.v9),
+        .tvOS(.v16)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "Networking",
+            targets: ["Networking"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "Networking"),
+        .testTarget(
+            name: "NetworkingTests",
+            dependencies: ["Networking"]
+        ),
+    ]
+)

--- a/Networking/Sources/Models/Customer.swift
+++ b/Networking/Sources/Models/Customer.swift
@@ -1,0 +1,20 @@
+//
+//  Customer.swift
+//  Networking
+//
+//  Created by User on 6/3/25.
+//
+
+public struct Customer: Codable, Identifiable, Sendable {
+    public let id: Int
+    public let name: String
+    public let latitude: Double
+    public let longitude: Double
+
+    public init(id: Int, name: String, latitude: Double, longitude: Double) {
+        self.id = id
+        self.name = name
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}

--- a/Networking/Sources/Models/Order.swift
+++ b/Networking/Sources/Models/Order.swift
@@ -1,0 +1,31 @@
+//
+//  Order.swift
+//  Networking
+//
+//  Created by User on 6/3/25.
+//
+
+public struct Order: Codable, Identifiable, Sendable, Equatable, Hashable {
+    public let id: Int
+    public let description: String
+    public let price: Double
+    public let customerID: Int
+    public let imageURL: String
+    public var status: OrderStatus
+
+    private enum CodingKeys: String, CodingKey {
+        case id, description, price
+        case customerID = "customer_id"
+        case imageURL = "image_url"
+        case status
+    }
+
+    public init(id: Int, description: String, price: Double, customerID: Int, imageURL: String, status: OrderStatus) {
+        self.id = id
+        self.description = description
+        self.price = price
+        self.customerID = customerID
+        self.imageURL = imageURL
+        self.status = status
+    }
+}

--- a/Networking/Sources/Models/OrderStatus.swift
+++ b/Networking/Sources/Models/OrderStatus.swift
@@ -1,0 +1,24 @@
+//
+//  OrderStatus.swift
+//  Networking
+//
+//  Created by User on 6/3/25.
+//
+
+public enum OrderStatus: String, CaseIterable, Codable, Sendable {
+    case new
+    case pending
+    case delivered
+
+    public var displayName: String {
+        rawValue.capitalized
+    }
+
+    public var systemImage: String {
+        switch self {
+        case .new: return "plus.circle"
+        case .pending: return "clock.circle"
+        case .delivered: return "checkmark.circle"
+        }
+    }
+}

--- a/Networking/Sources/NetworkError.swift
+++ b/Networking/Sources/NetworkError.swift
@@ -1,0 +1,25 @@
+//
+//  NetworkError.swift
+//  Networking
+//
+//  Created by User on 6/3/25.
+//
+
+import Foundation
+
+public enum NetworkError: LocalizedError {
+    case invalidURL
+    case invalidResponse
+    case decodingError(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL"
+        case .invalidResponse:
+            return "Invalid response from server"
+        case .decodingError(let error):
+            return "Failed to decode data: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Networking/Sources/Networking/Networking.swift
+++ b/Networking/Sources/Networking/Networking.swift
@@ -1,2 +1,0 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book

--- a/Networking/Sources/Networking/Networking.swift
+++ b/Networking/Sources/Networking/Networking.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Networking/Sources/Services/OrderService.swift
+++ b/Networking/Sources/Services/OrderService.swift
@@ -1,0 +1,55 @@
+//
+//  OrderService.swift
+//  Networking
+//
+//  Created by User on 6/3/25.
+//
+
+import Foundation
+
+public class OrderService {
+    private let baseURL = "http://demo7677712.mockable.io"
+    private let session = URLSession.shared
+
+    public init() {}
+
+    public func fetchOrders() async throws -> [Order] {
+        guard let url = URL(string: "\(baseURL)/orders") else {
+            throw NetworkError.invalidURL
+        }
+
+        let (data, response) = try await session.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw NetworkError.invalidResponse
+        }
+
+        do {
+            let orders = try JSONDecoder().decode([Order].self, from: data)
+            return orders
+        } catch {
+            throw NetworkError.decodingError(error)
+        }
+    }
+
+    public func fetchCustomers() async throws -> [Customer] {
+        guard let url = URL(string: "\(baseURL)/customers") else {
+            throw NetworkError.invalidURL
+        }
+
+        let (data, response) = try await session.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw NetworkError.invalidResponse
+        }
+
+        do {
+            let customers = try JSONDecoder().decode([Customer].self, from: data)
+            return customers
+        } catch {
+            throw NetworkError.decodingError(error)
+        }
+    }
+}

--- a/Networking/Tests/NetworkingTests/NetworkingTests.swift
+++ b/Networking/Tests/NetworkingTests/NetworkingTests.swift
@@ -1,0 +1,6 @@
+import Testing
+@testable import Networking
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+}


### PR DESCRIPTION
## Summary
Add local Swift Package for networking layer with API integration and data models

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Configuration/Setup

## Changes Made
- Create local Networking Swift Package for the project
- Add Order, Customer, and OrderStatus models
- Build OrderService with Swift Concurrency (async/await) for API calls
- Add NetworkError handling for common failure cases
- Set up ATS exception to allow HTTP calls to mockable.io

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Context
ATS exception is only for the demo API endpoint (would not use it in production).