### PR TITLE
feat: add order detail view with basic information display

### DIFF
--- a/FloraList/FloraList/Orders/OrderDetail/OrderDetailView.swift
+++ b/FloraList/FloraList/Orders/OrderDetail/OrderDetailView.swift
@@ -1,0 +1,121 @@
+//
+//  OrderDetailView.swift
+//  FloraList
+//
+//  Created by User on 6/3/25.
+//
+
+import SwiftUI
+import Networking
+
+struct OrderDetailView: View {
+    let order: Order
+    let customer: Customer?
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                orderImageSection
+                orderInfoSection
+                customerSection
+            }
+            .padding()
+        }
+        .navigationTitle("Order Details")
+        .navigationBarTitleDisplayMode(.large)
+    }
+
+    // MARK: - Sections
+
+    private var orderImageSection: some View {
+        AsyncImage(url: URL(string: order.imageURL)) { image in
+            image
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } placeholder: {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.gray.opacity(0.3))
+                .overlay {
+                    Image(systemName: "photo")
+                        .font(.title)
+                        .foregroundStyle(.secondary)
+                }
+        }
+        .frame(height: 200)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var orderInfoSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(order.description)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+
+                Text("$\(order.price, specifier: "%.2f")")
+                    .font(.title3)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack {
+                Label("Order #\(order.id)", systemImage: "number")
+                Spacer()
+                statusBadge
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var customerSection: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Customer Information")
+                        .font(.headline)
+                    Spacer()
+                }
+
+                if let customer = customer {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label(customer.name, systemImage: "person.fill")
+                        Label("Location: (\(customer.latitude), \(customer.longitude))", systemImage: "location.fill")
+                    }
+                    .font(.subheadline)
+                } else {
+                    Text("Customer information unavailable")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var statusBadge: some View {
+        Text(order.status.displayName)
+            .font(.caption)
+            .fontWeight(.medium)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(order.status.color.opacity(0.2))
+            .foregroundStyle(order.status.color)
+            .clipShape(Capsule())
+    }
+}
+
+#Preview {
+    NavigationStack {
+        OrderDetailView(
+            order: Order(
+                id: 1,
+                description: "Red Roses",
+                price: 50.0,
+                customerID: 1,
+                imageURL: "https://example.com/image.jpg",
+                status: .pending
+            ),
+            customer: Customer(id: 1, name: "John Doe", latitude: 46.562789, longitude: 23.784734)
+        )
+    }
+}

--- a/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
+++ b/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
@@ -66,7 +66,11 @@ struct OrdersListView: View {
 
     private var ordersView: some View {
         ForEach(viewModel.orders) { order in
-            OrderRowView(order: order, customer: viewModel.customer(for: order))
+            NavigationLink {
+                OrderDetailView(order: order, customer: viewModel.customer(for: order))
+            } label: {
+                OrderRowView(order: order, customer: viewModel.customer(for: order))
+            }
         }
     }
 }

--- a/FloraList/FloraList/Orders/OrdersList/OrdersListViewModel.swift
+++ b/FloraList/FloraList/Orders/OrdersList/OrdersListViewModel.swift
@@ -30,6 +30,10 @@ final class OrdersListViewModel {
         await fetchData()
     }
 
+    func customer(for order: Order) -> Customer? {
+        customers.first { $0.id == order.customerID }
+    }
+
     @MainActor
     private func fetchData() async {
         isLoading = true
@@ -46,9 +50,5 @@ final class OrdersListViewModel {
         }
 
         isLoading = false
-    }
-
-    func customer(for order: Order) -> Customer? {
-        customers.first { $0.id == order.customerID }
     }
 }

--- a/Networking/Sources/Models/OrderStatus.swift
+++ b/Networking/Sources/Models/OrderStatus.swift
@@ -5,6 +5,8 @@
 //  Created by User on 6/3/25.
 //
 
+import SwiftUI
+
 public enum OrderStatus: String, CaseIterable, Codable, Sendable {
     case new
     case pending
@@ -19,6 +21,14 @@ public enum OrderStatus: String, CaseIterable, Codable, Sendable {
         case .new: return "plus.circle"
         case .pending: return "clock.circle"
         case .delivered: return "checkmark.circle"
+        }
+    }
+
+    public var color: Color {
+        switch self {
+        case .new: return .blue
+        case .pending: return .orange
+        case .delivered: return .green
         }
     }
 }


### PR DESCRIPTION
## Summary
Add a detail view for orders that displays order information and customer details, accessible through navigation from the orders list.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Configuration/Setup

## Changes Made
- Added OrderDetailView displaying order image, price, and description
- Created customer information section showing name and location
- Implemented navigation from orders list to detail view
- Added status badge display in detail view

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## UI Testing (if applicable)
- [x] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [x] Works in both portrait and landscape
- [x] Dark/Light mode compatible
- [x] Accessibility considerations addressed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Context
- Navigation will be refactored when implementing coordinator pattern
