### PR TITLE
feat: add order status change functionality

### DIFF
--- a/FloraList/FloraList/Orders/OrderDetail/OrderDetailViewModel.swift
+++ b/FloraList/FloraList/Orders/OrderDetail/OrderDetailViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  OrderDetailViewModel.swift
+//  FloraList
+//
+//  Created by User on 6/3/25.
+//
+
+import Observation
+import Networking
+
+@Observable
+final class OrderDetailViewModel {
+    var order: Order
+    let customer: Customer?
+
+    init(order: Order, customer: Customer?) {
+        self.order = order
+        self.customer = customer
+    }
+
+    func updateStatus(_ newStatus: OrderStatus) {
+        order.status = newStatus
+    }
+}


### PR DESCRIPTION
## Summary
Implements order status change functionality in the order detail view, allowing users to update order status between new, pending, and delivered states. 

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Configuration/Setup

## Changes Made
- Added status change picker in order detail view with system-standard styling
- Implemented OrderDetailViewModel to handle status updates
- Added visual status indicators using system colors
- Integrated status change functionality with existing order model
- Enhanced UI with Form layout and semantic grouping for better accessibility

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## UI Testing (if applicable)
- [x] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [x] Works in both portrait and landscape
- [x] Dark/Light mode compatible
- [x] Accessibility considerations addressed

## Screenshots (if applicable)
<!-- Add your screenshot of the detail view here -->

## Additional Context
The implementation does not keep status changes in memory since we're using mockable.io for the API. In a production environment, this would be connected to backend status update endpoints.