### PR TITLE
feat: add orders search, filter, and sort functionality

### DIFF
--- a/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
+++ b/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
@@ -74,6 +74,7 @@ struct OrdersListView: View {
                 }
             }
         }
+        .listRowSeparator(.hidden)
     }
 
     private var loadingView: some View {

--- a/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
+++ b/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
@@ -12,6 +12,12 @@ struct OrdersListView: View {
     @State private var viewModel = OrdersListViewModel()
     @Environment(\.ordersCoordinator) private var coordinator
 
+    private var hasActiveFilters: Bool {
+        viewModel.selectedStatus != nil ||
+        viewModel.selectedSortOption != nil ||
+        !viewModel.searchText.isEmpty
+    }
+
     var body: some View {
         @Bindable var coordinator = coordinator
 
@@ -27,6 +33,12 @@ struct OrdersListView: View {
             }
             .listStyle(.plain)
             .navigationTitle("Orders")
+            .searchable(text: $viewModel.searchText, prompt: "Search orders...")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    filterSortMenu
+                }
+            }
             .refreshable {
                 await viewModel.refresh()
             }
@@ -46,6 +58,23 @@ struct OrdersListView: View {
     }
 
     // MARK: - Subviews
+
+    private var ordersView: some View {
+        Group {
+            if viewModel.filteredAndSortedOrders.isEmpty {
+                ContentUnavailableView.search(text: viewModel.searchText)
+            } else {
+                ForEach(viewModel.filteredAndSortedOrders) { order in
+                    Button {
+                        coordinator.showOrderDetail(order)
+                    } label: {
+                        OrderRowView(order: order, customer: viewModel.customer(for: order))
+                    }
+                    .contentShape(.rect)
+                }
+            }
+        }
+    }
 
     private var loadingView: some View {
         HStack {
@@ -76,14 +105,68 @@ struct OrdersListView: View {
         .listRowSeparator(.hidden)
     }
 
-    private var ordersView: some View {
-        ForEach(viewModel.orders) { order in
-            Button {
-                coordinator.showOrderDetail(order)
-            } label: {
-                OrderRowView(order: order, customer: viewModel.customer(for: order))
+    // MARK: - Filter and Sort Menus
+
+    private var filterSortMenu: some View {
+        Menu {
+            filterMenu
+            sortMenu
+
+            if viewModel.selectedStatus != nil ||
+                viewModel.selectedSortOption != nil ||
+                !viewModel.searchText.isEmpty {
+                Divider()
+
+                Button(role: .destructive) {
+                    viewModel.clearFilters()
+                } label: {
+                    Label("Clear All", systemImage: "xmark.circle.fill")
+                }
             }
-            .contentShape(.rect)
+        } label: {
+            Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
+                .symbolVariant(hasActiveFilters ? .fill : .none)
+        }
+    }
+
+    private var filterMenu: some View {
+        Menu {
+            ForEach(OrderStatus.allCases, id: \.self) { status in
+                Button {
+                    viewModel.selectedStatus = viewModel.selectedStatus == status ? nil : status
+                } label: {
+                    HStack {
+                        Label(status.displayName, systemImage: status.systemImage)
+                            .foregroundStyle(status.color)
+                        Spacer()
+                        if viewModel.selectedStatus == status {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            Label("Filter by Status", systemImage: "tag")
+        }
+    }
+
+    private var sortMenu: some View {
+        Menu {
+            ForEach(OrdersListViewModel.SortOption.allCases, id: \.self) { option in
+                Button {
+                    viewModel.selectedSortOption = viewModel.selectedSortOption == option ? nil : option
+                } label: {
+                    HStack {
+                        Text(option.rawValue)
+                        Spacer()
+                        if viewModel.selectedSortOption == option {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            Label("Sort Orders", systemImage: "arrow.up.arrow.down")
         }
     }
 }

--- a/FloraList/FloraList/Orders/OrdersList/OrdersListViewModel.swift
+++ b/FloraList/FloraList/Orders/OrdersList/OrdersListViewModel.swift
@@ -29,33 +29,10 @@ final class OrdersListViewModel {
     private let orderService = OrderService()
 
     var filteredAndSortedOrders: [Order] {
-        var result = orders
-
-        // Search
-        if !searchText.isEmpty {
-            result = result.filter { order in
-                order.description.localizedCaseInsensitiveContains(searchText)
-            }
-        }
-
-        // Filter by status
-        if let status = selectedStatus {
-            result = result.filter { $0.status == status }
-        }
-
-        // Sort
-        if let sortOption = selectedSortOption {
-            switch sortOption {
-            case .priceHighToLow:
-                result.sort { $0.price > $1.price }
-            case .priceLowToHigh:
-                result.sort { $0.price < $1.price }
-            case .status:
-                result.sort { $0.status.rawValue < $1.status.rawValue }
-            }
-        }
-
-        return result
+        orders
+            .search(with: searchText)
+            .filtered(by: selectedStatus)
+            .sorted(by: selectedSortOption)
     }
 
     // MARK: - Methods
@@ -97,5 +74,34 @@ final class OrdersListViewModel {
         }
 
         isLoading = false
+    }
+}
+
+// MARK: - Search, Filter and Sort
+
+private extension Array where Element == Order {
+    func search(with text: String) -> [Order] {
+        guard !text.isEmpty else { return self }
+        return filter { order in
+            order.description.localizedCaseInsensitiveContains(text)
+        }
+    }
+
+    func filtered(by status: OrderStatus?) -> [Order] {
+        guard let status else { return self }
+        return filter { $0.status == status }
+    }
+
+    func sorted(by option: OrdersListViewModel.SortOption?) -> [Order] {
+        guard let option else { return self }
+
+        switch option {
+        case .priceHighToLow:
+            return sorted { $0.price > $1.price }
+        case .priceLowToHigh:
+            return sorted { $0.price < $1.price }
+        case .status:
+            return sorted { $0.status.rawValue < $1.status.rawValue }
+        }
     }
 }


### PR DESCRIPTION
## Summary
Add search, filter, and sort functionality to the orders list, allowing users to find and organize their orders based on description, status, and price.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Configuration/Setup

## Changes Made
- Add search functionality to filter orders by description
- Implement status filtering (new/pending/delivered)
- Add sorting options for price (high to low/low to high) and status
- Keep filtering state in view model with computed results

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## UI Testing (if applicable)
- [x] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [x] Works in both portrait and landscape
- [x] Dark/Light mode compatible
- [x] Accessibility considerations addressed
  - Search field uses standard iOS search bar
  - Filter options in native menu

## Screenshots (if applicable)

## Additional Context
Considered Combine for debounced search but kept it simple for MVP
