### PR TITLE
feat: add deep linking support for order detail navigation

### DIFF
--- a/FloraList/FloraList.xcodeproj/project.pbxproj
+++ b/FloraList/FloraList.xcodeproj/project.pbxproj
@@ -464,7 +464,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.team.FloraList.FloraList;
+				PRODUCT_BUNDLE_IDENTIFIER = com.team.FloraList;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
@@ -503,7 +503,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.team.FloraList.FloraList;
+				PRODUCT_BUNDLE_IDENTIFIER = com.team.FloraList;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";

--- a/FloraList/FloraList/ContentView.swift
+++ b/FloraList/FloraList/ContentView.swift
@@ -8,14 +8,12 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var coordinator = OrdersCoordinator()
-
     var body: some View {
         OrdersListView()
-            .environment(\.ordersCoordinator, coordinator)
     }
 }
 
 #Preview {
     ContentView()
+        .environment(OrdersCoordinator())
 }

--- a/FloraList/FloraList/FloraListApp.swift
+++ b/FloraList/FloraList/FloraListApp.swift
@@ -9,9 +9,39 @@ import SwiftUI
 
 @main
 struct FloraListApp: App {
+    @State private var coordinator = OrdersCoordinator()
+    @State private var deepLinkManager = DeepLinkManager()
+    @State private var errorMessage: String?
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(coordinator)
+                .task {
+                    deepLinkManager.setup(with: coordinator)
+                }
+                .onOpenURL { url in
+                    Task {
+                        do {
+                            try await deepLinkManager.handle(url)
+                        } catch {
+                            errorMessage = error.localizedDescription
+                        }
+                    }
+                }
+                .alert("Deep Link Error",
+                       isPresented: .init(
+                        get: { errorMessage != nil },
+                        set: { if !$0 { errorMessage = nil } }
+                       )) {
+                    Button("OK") {
+                        errorMessage = nil
+                    }
+                } message: {
+                    if let errorMessage {
+                        Text(errorMessage)
+                    }
+                }
         }
     }
 }

--- a/FloraList/FloraList/Info.plist
+++ b/FloraList/FloraList/Info.plist
@@ -1,17 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>NSAppTransportSecurity</key>
-        <dict>
-            <key>NSExceptionDomains</key>
-            <dict>
-                <key>demo7677712.mockable.io</key>
-                <dict>
-                    <key>NSExceptionAllowsInsecureHTTPLoads</key>
-                    <true/>
-                </dict>
-            </dict>
-        </dict>
-    </dict>
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>floralist</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>com.team.FloraList</string>
+		</dict>
+	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>demo7677712.mockable.io</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/FloraList/FloraList/Navigation/DeepLinkManager.swift
+++ b/FloraList/FloraList/Navigation/DeepLinkManager.swift
@@ -1,0 +1,66 @@
+//
+//  DeepLinkManager.swift
+//  FloraList
+//
+//  Created by User on 6/4/25.
+//
+
+import SwiftUI
+import Networking
+
+@Observable
+final class DeepLinkManager {
+    private let orderService = OrderService()
+    private var ordersCoordinator: OrdersCoordinator?
+
+    enum DeepLinkError: LocalizedError {
+        case invalidURL
+        case orderNotFound
+        case invalidOrderId
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return "The URL is not valid"
+            case .orderNotFound:
+                return "Order not found"
+            case .invalidOrderId:
+                return "Invalid order ID"
+            }
+        }
+    }
+
+    func setup(with coordinator: OrdersCoordinator) {
+        self.ordersCoordinator = coordinator
+    }
+
+    func handle(_ url: URL) async throws {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+              components.scheme == "floralist" else {
+            throw DeepLinkError.invalidURL
+        }
+
+        switch components.host {
+        case "orders":
+            try await handleOrders(components)
+        default:
+            throw DeepLinkError.invalidURL
+        }
+    }
+
+    private func handleOrders(_ components: URLComponents) async throws {
+        guard let orderIdString = components.path.split(separator: "/").last,
+              let orderId = Int(orderIdString) else {
+            throw DeepLinkError.invalidOrderId
+        }
+
+        let orders = try await orderService.fetchOrders()
+        guard let order = orders.first(where: { $0.id == orderId }) else {
+            throw DeepLinkError.orderNotFound
+        }
+
+        await MainActor.run {
+            ordersCoordinator?.showOrderDetail(order)
+        }
+    }
+}

--- a/FloraList/FloraList/Orders/OrdersCoordinator.swift
+++ b/FloraList/FloraList/Orders/OrdersCoordinator.swift
@@ -30,14 +30,3 @@ final class OrdersCoordinator {
         }
     }
 }
-
-private struct OrdersCoordinatorKey: EnvironmentKey {
-    static let defaultValue = OrdersCoordinator()
-}
-
-extension EnvironmentValues {
-    var ordersCoordinator: OrdersCoordinator {
-        get { self[OrdersCoordinatorKey.self] }
-        set { self[OrdersCoordinatorKey.self] = newValue }
-    }
-}

--- a/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
+++ b/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
@@ -10,7 +10,7 @@ import Networking
 
 struct OrdersListView: View {
     @State private var viewModel = OrdersListViewModel()
-    @Environment(\.ordersCoordinator) private var coordinator
+    @Environment(OrdersCoordinator.self) private var coordinator
 
     private var hasActiveFilters: Bool {
         viewModel.selectedStatus != nil ||


### PR DESCRIPTION
## Summary
Add deep linking support to allow direct navigation to order details through custom URL scheme floralist://orders/{id}

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Configuration/Setup

## Changes Made
- Added DeepLinkManager to handle floralist:// URL scheme
- Implemented URL handling for orders/{id} path with error handling
- Added error alerts for invalid URLs and non-existent orders
- Integrated deep linking with existing OrdersCoordinator

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## UI Testing (if applicable)
- [x] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [x] Works in both portrait and landscape
- [x] Dark/Light mode compatible
- [x] Accessibility considerations addressed

## Screenshots (if applicable)

## Additional Context
Example deep link: `floralist://orders/20`