### PR TITLE
feat: implement bidirectional navigation between map and order details

### DIFF
--- a/FloraList/FloraList/ContentView.swift
+++ b/FloraList/FloraList/ContentView.swift
@@ -8,12 +8,32 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var selection: AppTab = .orders
+    @Environment(OrderManager.self) private var orderManager
+    @Environment(OrdersCoordinator.self) private var coordinator
+    @Environment(CustomerMapCoordinator.self) private var mapCoordinator
+    @Environment(DeepLinkManager.self) private var deepLinkManager
+
     var body: some View {
-        MainTabView()
+        MainTabView(selectedTab: $selection)
+            .task {
+                // Setup deep link manager with access to selection
+                deepLinkManager.setup(
+                    with: orderManager,
+                    coordinator: coordinator,
+                    mapCoordinator: mapCoordinator,
+                    selectedTab: $selection
+                )
+            }
     }
 }
 
 #Preview {
     ContentView()
+        .environment(OrderManager())
         .environment(OrdersCoordinator())
+        .environment(CustomerMapCoordinator())
+        .environment(DeepLinkManager())
+        .environment(NotificationManager())
+        .environment(LocationManager())
 }

--- a/FloraList/FloraList/FloraListApp.swift
+++ b/FloraList/FloraList/FloraListApp.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct FloraListApp: App {
     @State private var orderManager = OrderManager()
     @State private var coordinator = OrdersCoordinator()
+    @State private var mapCoordinator = CustomerMapCoordinator()
     @State private var deepLinkManager = DeepLinkManager()
     @State private var errorMessage: String?
     @State private var notificationManager = NotificationManager()
@@ -18,13 +19,14 @@ struct FloraListApp: App {
 
     var body: some Scene {
         WindowGroup {
-            MainTabView()
+            ContentView()
                 .environment(orderManager)
                 .environment(coordinator)
+                .environment(mapCoordinator)
                 .environment(notificationManager)
                 .environment(locationManager)
+                .environment(deepLinkManager)
                 .task {
-                    deepLinkManager.setup(with: orderManager, coordinator: coordinator)
                     await notificationManager.setup()
                     locationManager.requestLocationPermission()
                     // Initial data fetch

--- a/FloraList/FloraList/Map/CostumerMapCoordinator.swift
+++ b/FloraList/FloraList/Map/CostumerMapCoordinator.swift
@@ -1,0 +1,18 @@
+//
+//  CostumerMapCoordinator.swift
+//  FloraList
+//
+//  Created by User on 6/5/25.
+//
+
+import Observation
+import Networking
+
+@Observable
+final class CustomerMapCoordinator {
+    var selectedCustomer: Customer?
+
+    func showCustomer(_ customer: Customer) {
+        selectedCustomer = customer
+    }
+}

--- a/FloraList/FloraList/Map/CustomerMapView.swift
+++ b/FloraList/FloraList/Map/CustomerMapView.swift
@@ -12,7 +12,7 @@ import Networking
 struct CustomerMapView: View {
     @Environment(OrderManager.self) private var orderManager
     @Environment(LocationManager.self) private var locationManager
-    @State private var selectedCustomer: Customer?
+    @Environment(CustomerMapCoordinator.self) private var coordinator
     @State private var showingCustomerOrders = false
     @State private var showRoutes = true
     @State private var routes: [MKRoute] = []
@@ -55,7 +55,10 @@ struct CustomerMapView: View {
                     }
                 }
             }
-            .sheet(item: $selectedCustomer) { customer in
+            .sheet(item: .init(
+                get: { coordinator.selectedCustomer },
+                set: { coordinator.selectedCustomer = $0 }
+            )) { customer in
                 CustomerOrdersSheet(customer: customer)
             }
         }
@@ -66,7 +69,10 @@ struct CustomerMapView: View {
     private var mapView: some View {
         MapView(
             customers: orderManager.customers,
-            selectedCustomer: $selectedCustomer,
+            selectedCustomer: .init(
+                get: { coordinator.selectedCustomer },
+                set: { coordinator.selectedCustomer = $0 }
+            ),
             userLocation: locationManager.currentLocation?.coordinate,
             showRoutes: $showRoutes,
             routes: routes,
@@ -79,7 +85,7 @@ struct CustomerMapView: View {
                 await showOrderRoutesAsync()
             }
         }
-        .onChange(of: selectedCustomer) { _, customer in
+        .onChange(of: coordinator.selectedCustomer) { _, customer in
             if customer != nil {
                 showingCustomerOrders = true
             }

--- a/FloraList/FloraList/Navigation/AppTab.swift
+++ b/FloraList/FloraList/Navigation/AppTab.swift
@@ -5,6 +5,8 @@
 //  Created by User on 6/4/25.
 //
 
+import SwiftUI
+
 enum AppTab: Hashable {
     case orders
     case map
@@ -24,5 +26,17 @@ enum AppTab: Hashable {
         case .map: "map"
         case .settings: "gear"
         }
+    }
+}
+
+// Environment key for selected tab
+private struct SelectedTabKey: EnvironmentKey {
+    static let defaultValue: Binding<AppTab> = .constant(.orders)
+}
+
+extension EnvironmentValues {
+    var selectedTab: Binding<AppTab> {
+        get { self[SelectedTabKey.self] }
+        set { self[SelectedTabKey.self] = newValue }
     }
 }

--- a/FloraList/FloraList/Navigation/DeepLinkManager.swift
+++ b/FloraList/FloraList/Navigation/DeepLinkManager.swift
@@ -12,11 +12,15 @@ import Networking
 final class DeepLinkManager {
     private var orderManager: OrderManager?
     private var coordinator: OrdersCoordinator?
+    private var mapCoordinator: CustomerMapCoordinator?
+    private var selectedTab: Binding<AppTab>?
 
     enum DeepLinkError: LocalizedError {
         case invalidURL
         case orderNotFound
+        case customerNotFound
         case invalidOrderId
+        case invalidCustomerId
         case notConfigured
 
         var errorDescription: String? {
@@ -25,17 +29,23 @@ final class DeepLinkManager {
                 return "The URL is not valid"
             case .orderNotFound:
                 return "Order not found"
+            case .customerNotFound:
+                return "Customer not found"
             case .invalidOrderId:
                 return "Invalid order ID"
+            case .invalidCustomerId:
+                return "Invalid customer ID"
             case .notConfigured:
                 return "Deep linking is not configured properly"
             }
         }
     }
 
-    func setup(with manager: OrderManager, coordinator: OrdersCoordinator) {
+    func setup(with manager: OrderManager, coordinator: OrdersCoordinator, mapCoordinator: CustomerMapCoordinator, selectedTab: Binding<AppTab>? = nil) {
         self.orderManager = manager
         self.coordinator = coordinator
+        self.mapCoordinator = mapCoordinator
+        self.selectedTab = selectedTab
     }
 
     func handle(_ url: URL) async throws {
@@ -47,6 +57,8 @@ final class DeepLinkManager {
         switch components.host {
         case "orders":
             try await handleOrders(components)
+        case "map":
+            try await handleMap(components)
         default:
             throw DeepLinkError.invalidURL
         }
@@ -68,7 +80,46 @@ final class DeepLinkManager {
         }
 
         await MainActor.run {
-            coordinator.showOrderDetail(order)
+            coordinator.showOrderDetailFromDeepLink(order)
+        }
+    }
+
+    private func handleMap(_ components: URLComponents) async throws {
+        guard let orderManager = orderManager,
+              let mapCoordinator = mapCoordinator,
+              let selectedTab = selectedTab else {
+            throw DeepLinkError.notConfigured
+        }
+
+        let pathComponents = components.path.split(separator: "/")
+        
+        // Handle: floralist://map/customer/123
+        if pathComponents.count >= 2 && pathComponents[0] == "customer" {
+            guard let customerIdString = pathComponents[1].split(separator: "/").first,
+                  let customerId = Int(customerIdString) else {
+                throw DeepLinkError.invalidCustomerId
+            }
+            
+            guard let customer = orderManager.customers.first(where: { $0.id == customerId }) else {
+                throw DeepLinkError.customerNotFound
+            }
+            
+            await MainActor.run {
+                // Switch to map tab first
+                selectedTab.wrappedValue = .map
+            }
+            
+            // Wait for the tab switch to complete before presenting sheet
+            try await Task.sleep(for: .milliseconds(100))
+            
+            await MainActor.run {
+                mapCoordinator.showCustomer(customer)
+            }
+        } else {
+            // Handle: floralist://map (just switch to map tab)
+            await MainActor.run {
+                selectedTab.wrappedValue = .map
+            }
         }
     }
 }

--- a/FloraList/FloraList/Navigation/MainTabView.swift
+++ b/FloraList/FloraList/Navigation/MainTabView.swift
@@ -8,9 +8,10 @@
 import SwiftUI
 
 struct MainTabView: View {
-    @State private var selectedTab: AppTab = .orders
+    @Binding var selectedTab: AppTab
     @Environment(OrderManager.self) private var orderManager
     @Environment(NotificationManager.self) private var notificationManager
+    @Environment(LocationManager.self) private var locationManager
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -32,6 +33,7 @@ struct MainTabView: View {
                     Label(AppTab.settings.title, systemImage: AppTab.settings.icon)
                 }
         }
+        .environment(\.selectedTab, $selectedTab)
         .task {
             await orderManager.fetchData()
         }
@@ -39,7 +41,9 @@ struct MainTabView: View {
 }
 
 #Preview {
-    MainTabView()
+    @Previewable @State var selectedTab = AppTab.orders
+
+    MainTabView(selectedTab: $selectedTab)
         .environment(OrderManager())
         .environment(NotificationManager())
 }

--- a/FloraList/FloraList/Orders/OrdersCoordinator.swift
+++ b/FloraList/FloraList/Orders/OrdersCoordinator.swift
@@ -16,7 +16,14 @@ final class OrdersCoordinator {
         case orderDetail(Order)
     }
 
+    /// Normal navigation - appends to current stack
     func showOrderDetail(_ order: Order) {
+        navigationPath.append(Route.orderDetail(order))
+    }
+    
+    /// Deep link navigation - replaces stack with just this detail
+    func showOrderDetailFromDeepLink(_ order: Order) {
+        navigationPath = NavigationPath()
         navigationPath.append(Route.orderDetail(order))
     }
 


### PR DESCRIPTION
## Summary
Implements bidirectional navigation between map and order details with deep linking support.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring  
- [ ] Configuration/Setup

## Changes Made
- Add CustomerMapCoordinator for managing customer map navigation state
- Enable navigation from order details to customer location on map via deep linking
- Add navigation from customer map pins to order detail views
- Implement deep link URL handling for floralist://orders/{id} and floralist://map/customer/{id}
- Set up environment injection for OrderManager, coordinators, and managers

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## UI Testing (if applicable)
- [x] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [x] Works in both portrait and landscape
- [x] Dark/Light mode compatible
- [x] Accessibility considerations addressed

## Screenshots (if applicable)

## Additional Context
Note: In a real-world scenario, I would probably use simple navigation for map sheet to order details. However, I chose the deep linking approach here to demonstrate multiple deep link implementations.

Deep Link URLs:
- floralist://orders/20 - Navigate to specific order detail
- floralist://map/customer/601 - Navigate to customer location on map with sheet