### PR TITLE
fix: restore location services functionality for simulator testing

### DIFF
--- a/FloraList/FloraList/Map/MapView.swift
+++ b/FloraList/FloraList/Map/MapView.swift
@@ -28,16 +28,8 @@ struct MapView: UIViewRepresentable {
         mapView.showsUserLocation = true
         mapView.userTrackingMode = .none
 
-        // Set initial region - smart logic for simulator vs device
-        let centerCoordinate: CLLocationCoordinate2D
-        
-        #if targetEnvironment(simulator)
-        // Simulator: Always use Romania default for demo
-        centerCoordinate = Self.defaultCoordinate
-        #else
-        // Real device: Use user location if available, otherwise default
-        centerCoordinate = userLocation ?? Self.defaultCoordinate
-        #endif
+        // Set initial region - use user location if available, otherwise default
+        let centerCoordinate = userLocation ?? Self.defaultCoordinate
         
         let initialRegion = MKCoordinateRegion(
             center: centerCoordinate,
@@ -83,17 +75,7 @@ struct MapView: UIViewRepresentable {
             isCenteredOnUser = true
         }
 
-        #if targetEnvironment(simulator)
-        // Simulator: Always center on customers for demo
-        if !customers.isEmpty {
-            let coordinates = customers.map {
-                CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
-            }
-            let region = coordinateRegion(for: coordinates)
-            uiView.setRegion(region, animated: true)
-        }
-        #else
-        // Real device: Only auto center on customers if no user location
+        // Auto center on customers if no user location available
         if !customers.isEmpty && userLocation == nil {
             let coordinates = customers.map {
                 CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
@@ -101,7 +83,6 @@ struct MapView: UIViewRepresentable {
             let region = coordinateRegion(for: coordinates)
             uiView.setRegion(region, animated: true)
         }
-        #endif
     }
 
     func makeCoordinator() -> Coordinator {


### PR DESCRIPTION
## Summary
Remove simulator specific location overrides to allow location services to work consistently on simulator and device

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Configuration/Setup

## Changes Made
- Remove #if targetEnvironment(simulator) conditions in MapView
- Allow location services to work consistently on simulator and device

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## UI Testing (if applicable)
- [x] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [x] Works in both portrait and landscape
- [x] Dark/Light mode compatible
- [x] Accessibility considerations addressed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Context
Initially intended for simulator to always default to the customer pin coordinates for demo purposes, but this prevented route drawing from working properly.