### PR TITLE
feat: implement complete Settings screen with permission status indicators

### DIFF
--- a/FloraList/FloraList/Managers/OrderManager.swift
+++ b/FloraList/FloraList/Managers/OrderManager.swift
@@ -11,6 +11,7 @@ import Networking
 @Observable
 class OrderManager {
     private let orderService: OrderServiceProtocol
+    private(set) var networkingType: NetworkingType
 
     private(set) var orders: [Order] = []
     private(set) var customers: [Customer] = []
@@ -20,6 +21,7 @@ class OrderManager {
     // Default to GraphQL, but can be switched to REST
     init(networkingType: NetworkingType = .graphQL) {
         print("OrderManager using: \(networkingType)")
+        self.networkingType = networkingType
         self.orderService = ServiceFactory.createOrderService(type: networkingType)
     }
 

--- a/FloraList/FloraList/Map/CustomerOrdersSheet.swift
+++ b/FloraList/FloraList/Map/CustomerOrdersSheet.swift
@@ -86,7 +86,7 @@ struct CustomerOrdersSheet: View {
                     }
                 }
             }
-            .listSectionSpacing(20)
+            .listSectionSpacing(16)
             .contentMargins(.top, 16, for: .scrollContent)
             .navigationTitle("Customer Details")
             .navigationBarTitleDisplayMode(.inline)

--- a/FloraList/FloraList/Navigation/MainTabView.swift
+++ b/FloraList/FloraList/Navigation/MainTabView.swift
@@ -27,7 +27,7 @@ struct MainTabView: View {
                     Label(AppTab.map.title, systemImage: AppTab.map.icon)
                 }
 
-            Text("Settings")
+            SettingsView()
                 .tag(AppTab.settings)
                 .tabItem {
                     Label(AppTab.settings.title, systemImage: AppTab.settings.icon)

--- a/FloraList/FloraList/Orders/OrderDetail/OrderDetailView.swift
+++ b/FloraList/FloraList/Orders/OrderDetail/OrderDetailView.swift
@@ -45,7 +45,7 @@ private struct OrderDetailContentView: View {
             statusSection
             customerInfoSection
         }
-        .listSectionSpacing(20)
+        .listSectionSpacing(16)
         .contentMargins(.top, 16, for: .scrollContent)
         .navigationTitle(viewModel.order.description)
         .navigationBarTitleDisplayMode(.inline)
@@ -60,41 +60,37 @@ private struct OrderDetailContentView: View {
         AsyncImage(url: URL(string: viewModel.order.imageURL)) { image in
             image
                 .resizable()
-                .frame(height: 300)
-                .aspectRatio(contentMode: .fit)
+                .aspectRatio(contentMode: .fill)
+                .frame(height: 320)
+                .clipped()
         } placeholder: {
             RoundedRectangle(cornerRadius: 12)
                 .fill(Color.gray.opacity(0.3))
-                .frame(height: 300)
+                .frame(height: 320)
                 .overlay {
                     Image(systemName: "photo")
                         .font(.title)
                         .foregroundStyle(.secondary)
                 }
         }
-        .clipShape(RoundedRectangle(cornerRadius: 12))
         .listRowInsets(.init())
         .listRowBackground(Color.clear)
     }
 
     private var orderInfo: some View {
-        Section {
-            VStack(alignment: .leading) {
-                Text("$\(viewModel.order.price, specifier: "%.2f")")
-                    .font(.title3)
-                    .fontWeight(.medium)
-
-                LabeledContent("Order #\(viewModel.order.id)") {
-                    statusBadge
-                }
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-            }
+        LabeledContent("Order #\(viewModel.order.id)") {
+            Text("$\(viewModel.order.price, specifier: "%.2f")")
+                .font(.title3)
+                .fontWeight(.medium)
+                .foregroundStyle(.primary)
         }
+        .font(.callout)
+        .foregroundStyle(.secondary)
+        .padding(.vertical, 8)
     }
 
     private var statusSection: some View {
-        Section {
+
             Picker("Order Status", selection: .init(
                 get: { viewModel.order.status },
                 set: { viewModel.updateStatus($0) }
@@ -107,7 +103,7 @@ private struct OrderDetailContentView: View {
             }
             .pickerStyle(.menu)
         }
-    }
+
 
     private var customerInfoSection: some View {
         Section {
@@ -146,17 +142,6 @@ private struct OrderDetailContentView: View {
                     .foregroundStyle(.secondary)
             }
         }
-    }
-
-    private var statusBadge: some View {
-        Text(viewModel.order.status.displayName)
-            .font(.caption)
-            .fontWeight(.medium)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(viewModel.order.status.color.opacity(0.2))
-            .foregroundStyle(viewModel.order.status.color)
-            .clipShape(Capsule())
     }
 
     // MARK: - Actions

--- a/FloraList/FloraList/Settings/SettingsView.swift
+++ b/FloraList/FloraList/Settings/SettingsView.swift
@@ -1,0 +1,180 @@
+//
+//  SettingsView.swift
+//  FloraList
+//
+//  Created by User on 6/5/25.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(LocationManager.self) private var locationManager
+    @Environment(NotificationManager.self) private var notificationManager
+    @Environment(AnalyticsManager.self) private var analytics
+    @Environment(OrderManager.self) private var orderManager
+    @State private var showingLocationAlert = false
+    @State private var showingNotificationAlert = false
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+    }
+
+    private var networkingTypeText: String {
+        switch orderManager.networkingType {
+        case .rest:
+            return "REST"
+        case .graphQL:
+            return "GraphQL"
+        }
+    }
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section {
+                    locationRow
+                    notificationRow
+                } header: {
+                    Text("Permissions")
+                } footer: {
+                    Text("Tap any permission to change it in Settings.")
+                }
+
+                Section("About") {
+                    HStack {
+                        Text("Version")
+                        Spacer()
+                        Text(appVersion)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack {
+                        Text("Networking")
+                        Spacer()
+                        Text(networkingTypeText)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Settings")
+            .onAppear {
+                analytics.trackScreenView(screenName: "Settings")
+                // Refresh permission status when view appears
+                Task {
+                    await notificationManager.checkCurrentPermissionStatus()
+                }
+            }
+        }
+        .alert("Location Permission", isPresented: $showingLocationAlert) {
+            Button("Open Settings") {
+                openAppSettings()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("To \(locationManager.isLocationAvailable ? "disable" : "enable") location access, go to Settings > Privacy & Security > Location Services > FloraList.")
+        }
+        .alert("Notification Permission", isPresented: $showingNotificationAlert) {
+            Button("Open Settings") {
+                openAppSettings()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("To \(notificationManager.isPermissionGranted ? "disable" : "enable") notifications, go to Settings > Notifications > FloraList.")
+        }
+    }
+
+    private var locationRow: some View {
+        Button {
+            showingLocationAlert = true
+        } label: {
+            HStack {
+                Image(systemName: "location.fill")
+                    .foregroundColor(.blue)
+                    .frame(width: 20)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Location Services")
+                        .foregroundStyle(.primary)
+                    Text("Show distances and routes to customers")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                // Read-only status indicator
+                HStack(spacing: 6) {
+                    Text(locationManager.isLocationAvailable ? "Enabled" : "Disabled")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Image(systemName: locationManager.isLocationAvailable ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundStyle(locationManager.isLocationAvailable ? .green : .red)
+                        .font(.caption)
+
+                    // Chevron to indicate it's tappable
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var notificationRow: some View {
+        Button {
+            showingNotificationAlert = true
+        } label: {
+            HStack {
+                Image(systemName: "bell.fill")
+                    .foregroundColor(.orange)
+                    .frame(width: 20)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Notifications")
+                        .foregroundStyle(.primary)
+                    Text("Get updates when order status changes")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                // Read-only status indicator
+                HStack(spacing: 6) {
+                    Text(notificationManager.isPermissionGranted ? "Enabled" : "Disabled")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Image(systemName: notificationManager.isPermissionGranted ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundStyle(notificationManager.isPermissionGranted ? .green : .red)
+                        .font(.caption)
+
+                    // Chevron to indicate it's tappable
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func openAppSettings() {
+        guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+
+        if UIApplication.shared.canOpenURL(settingsUrl) {
+            UIApplication.shared.open(settingsUrl)
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+        .environment(LocationManager())
+        .environment(NotificationManager())
+        .environment(AnalyticsManager.shared)
+        .environment(OrderManager())
+}


### PR DESCRIPTION
## Summary
Replaces placeholder Settings with functional UI that displays permission status and app information.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Configuration/Setup

## Changes Made
- Build full Settings screen with permission status indicators
- Add location/notification status that directs users to iOS Settings
- Display dynamic app version from Info.plist
- Show networking type (REST/GraphQL) from OrderManager configuration
- Update UI for OrderDetailView and fix image sizing issue

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## UI Testing (if applicable)
- [x] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [x] Works in both portrait and landscape
- [x] Dark/Light mode compatible
- [x] Accessibility considerations addressed

## Screenshots (if applicable)

## Additional Context