### PR TITLE
Refactor/centralize order management

### DIFF
--- a/FloraList/FloraList/ContentView.swift
+++ b/FloraList/FloraList/ContentView.swift
@@ -30,7 +30,7 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
-        .environment(OrderManager())
+        .environment(OrderManager(notificationManager: NotificationManager()))
         .environment(OrdersCoordinator())
         .environment(CustomerMapCoordinator())
         .environment(DeepLinkManager())

--- a/FloraList/FloraList/FloraListApp.swift
+++ b/FloraList/FloraList/FloraListApp.swift
@@ -10,17 +10,20 @@ import FirebaseCore
 
 @main
 struct FloraListApp: App {
-    @State private var orderManager = OrderManager()
+    @State private var notificationManager = NotificationManager()
+    @State private var orderManager: OrderManager
     @State private var coordinator = OrdersCoordinator()
     @State private var mapCoordinator = CustomerMapCoordinator()
     @State private var deepLinkManager = DeepLinkManager()
     @State private var errorMessage: String?
-    @State private var notificationManager = NotificationManager()
     @State private var locationManager = LocationManager()
     @State private var analyticsManager = AnalyticsManager.shared
 
     init() {
         FirebaseApp.configure()
+        let notificationManager = NotificationManager()
+        self._notificationManager = State(initialValue: notificationManager)
+        self._orderManager = State(initialValue: OrderManager(notificationManager: notificationManager))
     }
 
     var body: some Scene {
@@ -36,8 +39,6 @@ struct FloraListApp: App {
                 .task {
                     await notificationManager.setup()
                     locationManager.requestLocationPermission()
-                    // Initial data fetch
-                    await orderManager.fetchData()
                 }
                 .onOpenURL { url in
                     Task {

--- a/FloraList/FloraList/Navigation/MainTabView.swift
+++ b/FloraList/FloraList/Navigation/MainTabView.swift
@@ -34,9 +34,6 @@ struct MainTabView: View {
                 }
         }
         .environment(\.selectedTab, $selectedTab)
-        .task {
-            await orderManager.fetchData()
-        }
     }
 }
 
@@ -44,6 +41,6 @@ struct MainTabView: View {
     @Previewable @State var selectedTab = AppTab.orders
 
     MainTabView(selectedTab: $selectedTab)
-        .environment(OrderManager())
+        .environment(OrderManager(notificationManager: NotificationManager()))
         .environment(NotificationManager())
 }

--- a/FloraList/FloraList/Orders/OrderDetail/OrderDetailView.swift
+++ b/FloraList/FloraList/Orders/OrderDetail/OrderDetailView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 import Networking
 
 struct OrderDetailView: View {
-    @Environment(NotificationManager.self) private var notificationManager
     @Environment(LocationManager.self) private var locationManager
     @Environment(DeepLinkManager.self) private var deepLinkManager
+    @Environment(OrderManager.self) private var orderManager
     private let order: Order
     private let customer: Customer?
 
@@ -25,7 +25,7 @@ struct OrderDetailView: View {
             viewModel: OrderDetailViewModel(
                 order: order,
                 customer: customer,
-                notificationManager: notificationManager
+                orderManager: orderManager
             ),
             locationManager: locationManager
         )
@@ -175,7 +175,7 @@ private struct OrderDetailContentView: View {
             customer: Customer(id: 1, name: "John Doe", latitude: 46.562789, longitude: 23.784734)
         )
     }
-    .environment(NotificationManager())
     .environment(LocationManager())
     .environment(DeepLinkManager())
+    .environment(OrderManager(notificationManager: NotificationManager()))
 }

--- a/FloraList/FloraList/Settings/SettingsView.swift
+++ b/FloraList/FloraList/Settings/SettingsView.swift
@@ -176,5 +176,5 @@ struct SettingsView: View {
         .environment(LocationManager())
         .environment(NotificationManager())
         .environment(AnalyticsManager.shared)
-        .environment(OrderManager())
+        .environment(OrderManager(notificationManager: NotificationManager()))
 }

--- a/FloraList/FloraListTests/Mocks/MockOrderManager.swift
+++ b/FloraList/FloraListTests/Mocks/MockOrderManager.swift
@@ -31,7 +31,7 @@ final class MockOrderManager: OrderManager {
     }
 
     static func withTestData() -> MockOrderManager {
-        let manager = MockOrderManager()
+        let manager = MockOrderManager(notificationManager: NotificationManager())
 
         let orders = [
             Order(id: 1, description: "Roses Bouquet", price: 45.99, customerID: 143, imageURL: "", status: .new),
@@ -54,6 +54,6 @@ final class MockOrderManager: OrderManager {
     }
 
     static func empty() -> MockOrderManager {
-        return MockOrderManager()
+        return MockOrderManager(notificationManager: NotificationManager())
     }
 } 

--- a/FloraList/FloraListTests/OrderManagerTests.swift
+++ b/FloraList/FloraListTests/OrderManagerTests.swift
@@ -25,7 +25,7 @@ struct OrderManagerTests {
 
     @Test("Fetch data loads orders and customers")
     func fetchDataLoadsOrdersAndCustomers() async {
-        let manager = OrderManager()
+        let manager = OrderManager(notificationManager: NotificationManager())
 
         await manager.fetchData()
 


### PR DESCRIPTION
## Summary
Centralize all order management logic in OrderManager and eliminate duplicate data fetching throughout the app. This refactoring consolidates analytics, notifications, and status updates while preventing multiple network calls on app launch.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Configuration/Setup

## Changes Made
- Move analytics and notification logic from OrderDetailViewModel to OrderManager
- Remove duplicate fetchData calls from FloraListApp and MainTabView  
- Add NotificationManager dependency and networking type parameter to OrderManager
- Update all OrderManager initialization sites across the app and tests
- Simplify OrderDetailViewModel to delegate status updates to OrderManager
- Fix OrderManagerTests and MockOrderManager constructors

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## UI Testing (if applicable)
- [x] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [x] Works in both portrait and landscape
- [x] Dark/Light mode compatible
- [x] Accessibility considerations addressed

## Screenshots (if applicable)

## Additional Context