### PR TITLE
feat: add API implementation picker to Settings for easy switching

### DIFF
--- a/FloraList/FloraList/Managers/OrderManager.swift
+++ b/FloraList/FloraList/Managers/OrderManager.swift
@@ -10,7 +10,7 @@ import Networking
 
 @Observable
 class OrderManager {
-    private let orderService: OrderServiceProtocol
+    private var orderService: OrderServiceProtocol
     private(set) var networkingType: NetworkingType
     private let analyticsManager = AnalyticsManager.shared
     private let notificationManager: NotificationManager
@@ -88,5 +88,15 @@ class OrderManager {
 
     func findOrder(by id: Int) -> Order? {
         orders.first { $0.id == id }
+    }
+    
+    @MainActor
+    func switchToNetworkingType(_ type: NetworkingType) async {
+        guard type != networkingType else { return }
+        
+        networkingType = type
+        orderService = ServiceFactory.createOrderService(type: type)
+
+        await fetchData()
     }
 }

--- a/FloraList/FloraList/Settings/SettingsView.swift
+++ b/FloraList/FloraList/Settings/SettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Networking
 
 struct SettingsView: View {
     @Environment(LocationManager.self) private var locationManager
@@ -39,19 +40,20 @@ struct SettingsView: View {
                 } footer: {
                     Text("Tap any permission to change it in Settings.")
                 }
-
+                
+                Section {
+                    networkingRow
+                } header: {
+                    Text("Developer")
+                } footer: {
+                    Text("Switch between REST and GraphQL networking implementations.")
+                }
+                
                 Section("About") {
                     HStack {
                         Text("Version")
                         Spacer()
                         Text(appVersion)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    HStack {
-                        Text("Networking")
-                        Spacer()
-                        Text(networkingTypeText)
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -168,6 +170,21 @@ struct SettingsView: View {
         if UIApplication.shared.canOpenURL(settingsUrl) {
             UIApplication.shared.open(settingsUrl)
         }
+    }
+    
+    private var networkingRow: some View {
+        Picker("API Implementation", selection: Binding(
+            get: { orderManager.networkingType },
+            set: { newType in
+                Task {
+                    await orderManager.switchToNetworkingType(newType)
+                }
+            }
+        )) {
+            Text("REST").tag(NetworkingType.rest)
+            Text("GraphQL").tag(NetworkingType.graphQL)
+        }
+        .pickerStyle(.menu)
     }
 }
 


### PR DESCRIPTION
Allows switch between REST and GraphQL networking backends with a picker.

## Summary
Add API implementation picker to Settings for easy switching

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Configuration/Setup

## Changes Made
- Add switch between REST and GraphQL networking backends with a picker.

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## UI Testing (if applicable)
- [ ] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [ ] Works in both portrait and landscape
- [ ] Dark/Light mode compatible
- [x] Accessibility considerations addressed

## Screenshots (if applicable)

## Additional Context
