### PR TITLE
refactor: add DTOs, mappers, and shared lazy JSONDecoder for networking

### DIFF
--- a/FloraList/FloraList/Navigation/MainTabView.swift
+++ b/FloraList/FloraList/Navigation/MainTabView.swift
@@ -9,9 +9,6 @@ import SwiftUI
 
 struct MainTabView: View {
     @Binding var selectedTab: AppTab
-    @Environment(OrderManager.self) private var orderManager
-    @Environment(NotificationManager.self) private var notificationManager
-    @Environment(LocationManager.self) private var locationManager
 
     var body: some View {
         TabView(selection: $selectedTab) {

--- a/Networking/Sources/Models/Customer.swift
+++ b/Networking/Sources/Models/Customer.swift
@@ -18,3 +18,14 @@ public struct Customer: Codable, Identifiable, Sendable, Equatable {
         self.longitude = longitude
     }
 }
+
+struct CustomerMapper {
+    static func map(dto: CustomerDTO) -> Customer {
+        Customer(
+            id: dto.id,
+            name: dto.name,
+            latitude: dto.latitude,
+            longitude: dto.longitude
+        )
+    }
+}

--- a/Networking/Sources/Models/CustomerDTO.swift
+++ b/Networking/Sources/Models/CustomerDTO.swift
@@ -1,0 +1,13 @@
+//
+//  CustomerDTO.swift
+//  Networking
+//
+//  Created by User on 6/17/25.
+//
+
+struct CustomerDTO: Codable {
+    let id: Int
+    let name: String
+    let latitude: Double
+    let longitude: Double
+}

--- a/Networking/Sources/Models/Order.swift
+++ b/Networking/Sources/Models/Order.swift
@@ -13,13 +13,6 @@ public struct Order: Codable, Identifiable, Sendable, Equatable, Hashable {
     public let imageURL: String
     public var status: OrderStatus
 
-    private enum CodingKeys: String, CodingKey {
-        case id, description, price
-        case customerID = "customer_id"
-        case imageURL = "image_url"
-        case status
-    }
-
     public init(id: Int, description: String, price: Double, customerID: Int, imageURL: String, status: OrderStatus) {
         self.id = id
         self.description = description
@@ -27,5 +20,18 @@ public struct Order: Codable, Identifiable, Sendable, Equatable, Hashable {
         self.customerID = customerID
         self.imageURL = imageURL
         self.status = status
+    }
+}
+
+struct OrderMapper {
+    static func map(dto: OrderDTO) -> Order {
+        Order(
+            id: dto.id,
+            description: dto.description,
+            price: dto.price,
+            customerID: dto.customerId,
+            imageURL: dto.imageUrl,
+            status: OrderStatus(rawValue: dto.status ?? "") ?? .new
+        )
     }
 }

--- a/Networking/Sources/Models/OrderDTO.swift
+++ b/Networking/Sources/Models/OrderDTO.swift
@@ -1,0 +1,15 @@
+//
+//  OrderDTO.swift
+//  Networking
+//
+//  Created by User on 6/17/25.
+//
+
+struct OrderDTO: Codable {
+    let id: Int
+    let description: String
+    let price: Double
+    let customerId: Int
+    let imageUrl: String
+    let status: String?
+}

--- a/Networking/Sources/Services/GraphQLOrderService.swift
+++ b/Networking/Sources/Services/GraphQLOrderService.swift
@@ -11,6 +11,12 @@ public class GraphQLOrderService {
     private let session: URLSession
     private let baseURL = "https://ba8312ca-45f2-4ed3-86b6-047cf8926e92.mock.pstmn.io/graphql"
 
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+
     public init(session: URLSession = .shared) {
         self.session = session
     }
@@ -32,7 +38,7 @@ public class GraphQLOrderService {
         """
 
         let response = try await executeGraphQLQuery(query: query)
-        let graphqlResponse = try JSONDecoder().decode(GraphQLOrdersResponse.self, from: response)
+        let graphqlResponse = try Self.decoder.decode(GraphQLOrdersResponse.self, from: response)
         let orders: [Order] = graphqlResponse.data.orders.compactMap { graphQLOrder in
             // Handle missing or invalid status field by defaulting to .new
             let status = graphQLOrder.status.flatMap { OrderStatus(rawValue: $0) } ?? .new
@@ -66,7 +72,7 @@ public class GraphQLOrderService {
         """
 
         let response = try await executeGraphQLQuery(query: query)
-        let graphqlResponse = try JSONDecoder().decode(GraphQLCustomersResponse.self, from: response)
+        let graphqlResponse = try Self.decoder.decode(GraphQLCustomersResponse.self, from: response)
         let customers = graphqlResponse.data.customers.map { graphQLCustomer in
             Customer(
                 id: graphQLCustomer.id,

--- a/Networking/Sources/Services/OrderService.swift
+++ b/Networking/Sources/Services/OrderService.swift
@@ -11,6 +11,12 @@ public class OrderService {
     private let baseURL = "http://demo7677712.mockable.io"
     private let session: URLSession
 
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+
     public init(session: URLSession = .shared) {
         self.session = session
     }
@@ -30,7 +36,8 @@ public class OrderService {
         }
 
         do {
-            let orders = try JSONDecoder().decode([Order].self, from: data)
+            let orderDTOs = try Self.decoder.decode([OrderDTO].self, from: data)
+            let orders = orderDTOs.map(OrderMapper.map)
             print("REST: Successfully fetched \(orders.count) orders")
             return orders
         } catch {
@@ -53,7 +60,8 @@ public class OrderService {
         }
 
         do {
-            let customers = try JSONDecoder().decode([Customer].self, from: data)
+            let customerDTOs = try Self.decoder.decode([CustomerDTO].self, from: data)
+            let customers = customerDTOs.map(CustomerMapper.map)
             print("REST: Successfully fetched \(customers.count) customers")
             return customers
         } catch {


### PR DESCRIPTION
## Summary
Refactored the networking layer to introduce DTOs and mappers, and implemented a shared lazy JSONDecoder for consistent and maintainable API decoding. Improved separation of concerns and removed redundant code.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Configuration/Setup

## Changes Made
- Introduced OrderDTO and CustomerDTO for decoding API responses
- Added OrderMapper and CustomerMapper to convert DTOs to domain models
- Implemented a shared lazy JSONDecoder with .convertFromSnakeCase in both OrderService and GraphQLOrderService
- Removed redundant CodingKeys from domain models
- Improved separation of concerns and future-proofed networking layer
- Removed unused environment properties from the MainTabView.

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## UI Testing (if applicable)
- [ ] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [ ] Works in both portrait and landscape
- [ ] Dark/Light mode compatible
- [ ] Accessibility considerations addressed

## Screenshots (if applicable)

## Additional Context
