### PR TITLE
feat: add localization using String Catalog with multi-language support

### DIFF
--- a/FloraList/FloraList/FloraListApp.swift
+++ b/FloraList/FloraList/FloraListApp.swift
@@ -18,6 +18,7 @@ struct FloraListApp: App {
     @State private var locationManager = LocationManager()
     @State private var routeManager: RouteManager
     @State private var analyticsManager = AnalyticsManager.shared
+    @State private var localizationManager = LocalizationManager.shared
 
     @State private var deepLinkErrorMessage: String?
 
@@ -42,6 +43,8 @@ struct FloraListApp: App {
                 .environment(routeManager)
                 .environment(deepLinkManager)
                 .environment(analyticsManager)
+                .environment(localizationManager)
+                .environment(\.locale, localizationManager.currentLanguage.locale)
                 .task {
                     await notificationManager.setup()
                     locationManager.requestLocationPermission()
@@ -55,13 +58,15 @@ struct FloraListApp: App {
                         }
                     }
                 }
-                .alert("Deep Link Error",
+                .alert(Text(.deepLinkError),
                        isPresented: .init(
                         get: { deepLinkErrorMessage != nil },
                         set: { if !$0 { deepLinkErrorMessage = nil } }
                        )) {
-                    Button("OK") {
+                    Button {
                         deepLinkErrorMessage = nil
+                    } label: {
+                        Text(.ok)
                     }
                 } message: {
                     if let deepLinkErrorMessage {

--- a/FloraList/FloraList/Localizable.xcstrings
+++ b/FloraList/FloraList/Localizable.xcstrings
@@ -2,31 +2,31 @@
   "sourceLanguage" : "en",
   "strings" : {
     "%@ • %@" : {
-      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ • %2$@"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@ • %2$@"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "$%.0f" : {
-
+      "shouldTranslate" : false
     },
     "$%.2f" : {
-
+      "shouldTranslate" : false
     },
     "about" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Über"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44,6 +44,12 @@
     "api_implementation" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Implementierung"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61,6 +67,12 @@
     "calculating_distance" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird berechnet..."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -78,6 +90,12 @@
     "cancel" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbrechen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -92,12 +110,15 @@
         }
       }
     },
-    "Clear All" : {
-
-    },
     "clear_all" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle löschen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -115,6 +136,12 @@
     "customer_details" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kundendetails"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -132,6 +159,12 @@
     "customer_id_format" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunden-ID: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -149,6 +182,12 @@
     "customer_information_unavailable" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kundeninformationen nicht verfügbar"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -166,6 +205,12 @@
     "customer_locations" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kundenstandorte"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -180,9 +225,37 @@
         }
       }
     },
+    "customer_no_orders_message" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Kunde hat noch keine Bestellungen aufgegeben."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This customer hasn't placed any orders yet."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este cliente aún no ha realizado ningún pedido."
+          }
+        }
+      }
+    },
     "deep_link_error" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deep-Link-Fehler"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -200,6 +273,12 @@
     "developer" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entwickler"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -217,6 +296,12 @@
     "developer_settings_description" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischen REST- und GraphQL-Netzwerkimplementierungen wechseln."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -234,6 +319,12 @@
     "disabled" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deaktiviert"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -251,6 +342,12 @@
     "distance_unavailable" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernung nicht verfügbar"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -268,6 +365,12 @@
     "done" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -285,6 +388,12 @@
     "enable_location_for_distance" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standort für Entfernung aktivieren"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -302,6 +411,12 @@
     "enabled" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktiviert"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -320,6 +435,12 @@
       "comment" : "English language option",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Englisch"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -337,6 +458,12 @@
     "filter" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -351,12 +478,15 @@
         }
       }
     },
-    "Filter" : {
-
-    },
     "filter_by_status" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nach Status filtern"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -371,9 +501,39 @@
         }
       }
     },
+    "german" : {
+      "comment" : "German language option",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deutsch"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "German"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alemán"
+          }
+        }
+      }
+    },
     "graphql" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GraphQL"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -392,6 +552,12 @@
       "comment" : "Language settings section header",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprache"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -410,6 +576,12 @@
       "comment" : "Language settings description",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Änderungen werden beim nächsten App-Start wirksam."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -427,6 +599,12 @@
     "latitude_longitude_format" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lat: %@, Lon: %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -444,6 +622,12 @@
     "loading_customer_locations" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lade Kundenstandorte..."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -461,6 +645,12 @@
     "loading_orders" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lade Bestellungen..."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -478,6 +668,12 @@
     "location_permission" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standortberechtigung"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -495,6 +691,12 @@
     "location_services" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ortungsdienste"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -512,16 +714,22 @@
     "location_services_description" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktivieren Sie Ortungsdienste, um Entfernungen zu Kunden anzuzeigen."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Show distances and routes to customers"
+            "value" : "Enable location services to show distances to customers."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mostrar distancias y rutas a clientes"
+            "value" : "Habilita los servicios de ubicación para mostrar distancias a los clientes."
           }
         }
       }
@@ -529,6 +737,12 @@
     "map" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karte"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -543,12 +757,15 @@
         }
       }
     },
-    "No Orders" : {
-
-    },
     "no_orders_yet" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch keine Bestellungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -566,6 +783,12 @@
     "notification_permission" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benachrichtigungsberechtigung"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -583,6 +806,12 @@
     "notifications" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benachrichtigungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -600,16 +829,22 @@
     "notifications_description" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benachrichtigungen erhalten, wenn sich der Bestellstatus ändert."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Get updates when order status changes"
+            "value" : "Receive notifications when order status changes."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recibir actualizaciones cuando cambie el estado del pedido"
+            "value" : "Recibe notificaciones cuando cambie el estado del pedido."
           }
         }
       }
@@ -617,6 +852,12 @@
     "ok" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -634,6 +875,12 @@
     "open_settings" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen öffnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -651,6 +898,12 @@
     "order_id_format" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestellung #%@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -668,6 +921,12 @@
     "order_status_delivered" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geliefert"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -685,6 +944,12 @@
     "order_status_new" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neu"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -702,6 +967,12 @@
     "order_status_pending" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ausstehend"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -719,6 +990,12 @@
     "order_status_updated" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestellstatus aktualisiert"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -736,6 +1013,12 @@
     "order_status_updated_body" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestellung #%@ (%@) ist jetzt %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -753,6 +1036,12 @@
     "orders" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestellungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -767,12 +1056,38 @@
         }
       }
     },
-    "Orders (%lld)" : {
-
+    "orders_with_count" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestellungen (%lld)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orders (%lld)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pedidos (%lld)"
+          }
+        }
+      }
     },
     "permissions" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berechtigungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -790,6 +1105,12 @@
     "permissions_description" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App-Berechtigungen für optimale Erfahrung verwalten."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -807,6 +1128,12 @@
     "rest" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "REST"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -824,6 +1151,12 @@
     "search_orders" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestellungen suchen..."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -841,6 +1174,12 @@
     "settings" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -855,12 +1194,15 @@
         }
       }
     },
-    "Sort Orders" : {
-
-    },
     "sort_orders" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestellungen sortieren"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -878,6 +1220,12 @@
     "sort_price_high_to_low" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preis: Hoch zu Niedrig"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -895,6 +1243,12 @@
     "sort_price_low_to_high" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preis: Niedrig zu Hoch"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -912,6 +1266,12 @@
     "sort_status" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -930,6 +1290,12 @@
       "comment" : "Spanish language option",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spanisch"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -944,15 +1310,15 @@
         }
       }
     },
-    "This customer hasn't placed any orders yet." : {
-
-    },
-    "Try Again" : {
-
-    },
     "try_again" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erneut versuchen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -967,12 +1333,15 @@
         }
       }
     },
-    "Unable to Load Orders" : {
-
-    },
     "unable_to_load_locations" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standorte können nicht geladen werden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -990,6 +1359,12 @@
     "unable_to_load_orders" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestellungen können nicht geladen werden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1007,6 +1382,12 @@
     "version" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1024,6 +1405,12 @@
     "view_on_map" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auf Karte anzeigen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/FloraList/FloraList/Localizable.xcstrings
+++ b/FloraList/FloraList/Localizable.xcstrings
@@ -1,0 +1,1043 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "%@ • %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ • %2$@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ • %2$@"
+          }
+        }
+      }
+    },
+    "$%.0f" : {
+
+    },
+    "$%.2f" : {
+
+    },
+    "about" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acerca de"
+          }
+        }
+      }
+    },
+    "api_implementation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API Implementation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Implementación de API"
+          }
+        }
+      }
+    },
+    "calculating_distance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calculating..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calculando..."
+          }
+        }
+      }
+    },
+    "cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        }
+      }
+    },
+    "Clear All" : {
+
+    },
+    "clear_all" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear All"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar Todo"
+          }
+        }
+      }
+    },
+    "customer_details" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Customer Details"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalles del Cliente"
+          }
+        }
+      }
+    },
+    "customer_id_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Customer ID: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID del Cliente: %@"
+          }
+        }
+      }
+    },
+    "customer_information_unavailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Customer information unavailable"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Información del cliente no disponible"
+          }
+        }
+      }
+    },
+    "customer_locations" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Customer Locations"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ubicaciones de Clientes"
+          }
+        }
+      }
+    },
+    "deep_link_error" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deep Link Error"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de Enlace Profundo"
+          }
+        }
+      }
+    },
+    "developer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Developer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desarrollador"
+          }
+        }
+      }
+    },
+    "developer_settings_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch between REST and GraphQL networking implementations."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar entre implementaciones de red REST y GraphQL."
+          }
+        }
+      }
+    },
+    "disabled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disabled"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deshabilitado"
+          }
+        }
+      }
+    },
+    "distance_unavailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distance unavailable"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distancia no disponible"
+          }
+        }
+      }
+    },
+    "done" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listo"
+          }
+        }
+      }
+    },
+    "enable_location_for_distance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable location for distance"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habilitar ubicación para distancia"
+          }
+        }
+      }
+    },
+    "enabled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enabled"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habilitado"
+          }
+        }
+      }
+    },
+    "english" : {
+      "comment" : "English language option",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "English"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inglés"
+          }
+        }
+      }
+    },
+    "filter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrar"
+          }
+        }
+      }
+    },
+    "Filter" : {
+
+    },
+    "filter_by_status" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter by Status"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrar por Estado"
+          }
+        }
+      }
+    },
+    "graphql" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GraphQL"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GraphQL"
+          }
+        }
+      }
+    },
+    "language" : {
+      "comment" : "Language settings section header",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Language"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idioma"
+          }
+        }
+      }
+    },
+    "language_description" : {
+      "comment" : "Language settings description",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose your preferred language. Changes will take effect when you restart the app."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige tu idioma preferido. Los cambios tomarán efecto cuando reinicies la aplicación."
+          }
+        }
+      }
+    },
+    "latitude_longitude_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lat: %@, Lon: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lat: %@, Lon: %@"
+          }
+        }
+      }
+    },
+    "loading_customer_locations" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading customer locations..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando ubicaciones de clientes..."
+          }
+        }
+      }
+    },
+    "loading_orders" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading orders..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando pedidos..."
+          }
+        }
+      }
+    },
+    "location_permission" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Location Permission"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permiso de Ubicación"
+          }
+        }
+      }
+    },
+    "location_services" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Location Services"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servicios de Ubicación"
+          }
+        }
+      }
+    },
+    "location_services_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show distances and routes to customers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar distancias y rutas a clientes"
+          }
+        }
+      }
+    },
+    "map" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Map"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mapa"
+          }
+        }
+      }
+    },
+    "No Orders" : {
+
+    },
+    "no_orders_yet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No orders yet"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay pedidos"
+          }
+        }
+      }
+    },
+    "notification_permission" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notification Permission"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permiso de Notificaciones"
+          }
+        }
+      }
+    },
+    "notifications" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notificaciones"
+          }
+        }
+      }
+    },
+    "notifications_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get updates when order status changes"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recibir actualizaciones cuando cambie el estado del pedido"
+          }
+        }
+      }
+    },
+    "ok" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
+    },
+    "open_settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Settings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir Configuración"
+          }
+        }
+      }
+    },
+    "order_id_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Order #%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pedido #%@"
+          }
+        }
+      }
+    },
+    "order_status_delivered" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delivered"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entregado"
+          }
+        }
+      }
+    },
+    "order_status_new" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nuevo"
+          }
+        }
+      }
+    },
+    "order_status_pending" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pending"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendiente"
+          }
+        }
+      }
+    },
+    "order_status_updated" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Order Status Updated"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado del Pedido Actualizado"
+          }
+        }
+      }
+    },
+    "order_status_updated_body" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Order #%@ (%@) is now %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El pedido #%@ (%@) ahora está %@"
+          }
+        }
+      }
+    },
+    "orders" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pedidos"
+          }
+        }
+      }
+    },
+    "Orders (%lld)" : {
+
+    },
+    "permissions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permissions"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permisos"
+          }
+        }
+      }
+    },
+    "permissions_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap any permission to change it in Settings."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca cualquier permiso para cambiarlo en Configuración."
+          }
+        }
+      }
+    },
+    "rest" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "REST"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "REST"
+          }
+        }
+      }
+    },
+    "search_orders" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search orders..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar pedidos..."
+          }
+        }
+      }
+    },
+    "settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuración"
+          }
+        }
+      }
+    },
+    "Sort Orders" : {
+
+    },
+    "sort_orders" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sort Orders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordenar Pedidos"
+          }
+        }
+      }
+    },
+    "sort_price_high_to_low" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Price: High to Low"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Precio: Mayor a Menor"
+          }
+        }
+      }
+    },
+    "sort_price_low_to_high" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Price: Low to High"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Precio: Menor a Mayor"
+          }
+        }
+      }
+    },
+    "sort_status" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado"
+          }
+        }
+      }
+    },
+    "spanish" : {
+      "comment" : "Spanish language option",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spanish"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Español"
+          }
+        }
+      }
+    },
+    "This customer hasn't placed any orders yet." : {
+
+    },
+    "Try Again" : {
+
+    },
+    "try_again" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try Again"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intentar de Nuevo"
+          }
+        }
+      }
+    },
+    "Unable to Load Orders" : {
+
+    },
+    "unable_to_load_locations" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to Load Locations"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se Pueden Cargar las Ubicaciones"
+          }
+        }
+      }
+    },
+    "unable_to_load_orders" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to Load Orders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se Pueden Cargar los Pedidos"
+          }
+        }
+      }
+    },
+    "version" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versión"
+          }
+        }
+      }
+    },
+    "view_on_map" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View on Map"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver en Mapa"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/FloraList/FloraList/Map/CustomerMap/Components/CustomerAnnotation.swift
+++ b/FloraList/FloraList/Map/CustomerMap/Components/CustomerAnnotation.swift
@@ -36,7 +36,7 @@ final class CustomerAnnotation: NSObject, MKAnnotation {
         if !components.isEmpty {
             return components.joined(separator: " • ")
         } else {
-            return "Customer ID: \(customer.id)"
+            return String(localized: .customerIdFormat(String(customer.id)))
         }
     }
 

--- a/FloraList/FloraList/Map/CustomerMap/CustomerMapView.swift
+++ b/FloraList/FloraList/Map/CustomerMap/CustomerMapView.swift
@@ -22,7 +22,7 @@ struct CustomerMapView: View {
                     routeManager: routeManager
                 )
             )
-            .navigationTitle("Customer Locations")
+            .navigationTitle(Text(.customerLocations))
             .navigationBarTitleDisplayMode(.inline)
         }
         .sheet(item: .init(
@@ -95,21 +95,27 @@ private struct CustomerMapContentView: View {
     private var loadingView: some View {
         VStack {
             ProgressView()
-            Text("Loading customer locations...")
+            Text(.loadingCustomerLocations)
                 .foregroundStyle(.secondary)
         }
     }
 
     private func errorView(_ message: String) -> some View {
         ContentUnavailableView {
-            Label("Unable to Load Locations", systemImage: "map.fill")
+            Label {
+                Text(.unableToLoadLocations)
+            } icon: {
+                Image(systemName: "map.fill")
+            }
         } description: {
             Text(message)
         } actions: {
-            Button("Try Again") {
+            Button {
                 Task { 
                     await viewModel.retryDataFetch()
                 }
+            } label: {
+                Text(.tryAgain)
             }
             .buttonStyle(.borderedProminent)
         }

--- a/FloraList/FloraList/Map/CustomerOrderSheet/CustomerOrdersSheet.swift
+++ b/FloraList/FloraList/Map/CustomerOrderSheet/CustomerOrdersSheet.swift
@@ -82,12 +82,16 @@ private struct CustomerOrdersSheetContentView: View {
                 .padding(.vertical, 4)
             }
 
-            Section("Orders (\(viewModel.ordersCount))") {
+            Section {
                 if !viewModel.hasOrders {
                     ContentUnavailableView {
-                        Label("No Orders", systemImage: "list.bullet")
+                        Label {
+                            Text(.noOrdersYet)
+                        } icon: {
+                            Image(systemName: "list.bullet")
+                        }
                     } description: {
-                        Text("This customer hasn't placed any orders yet.")
+                        Text(.customerNoOrdersMessage)
                     }
                     .listRowBackground(Color.clear)
                 } else {
@@ -99,6 +103,8 @@ private struct CustomerOrdersSheetContentView: View {
                         }
                     }
                 }
+            } header: {
+                Text(.ordersWithCount(viewModel.ordersCount))
             }
         }
         .listSectionSpacing(16)

--- a/FloraList/FloraList/Map/CustomerOrderSheet/CustomerOrdersSheet.swift
+++ b/FloraList/FloraList/Map/CustomerOrderSheet/CustomerOrdersSheet.swift
@@ -28,7 +28,7 @@ struct CustomerOrdersSheet: View {
                     routeManager: routeManager
                 )
             )
-            .navigationTitle("Customer Details")
+            .navigationTitle(Text(.customerDetails))
             .navigationBarTitleDisplayMode(.inline)
         }
         .presentationDetents([.medium, .large])
@@ -55,7 +55,7 @@ private struct CustomerOrdersSheetContentView: View {
                         VStack(alignment: .leading) {
                             Text(viewModel.customer.name)
                                 .font(.headline)
-                            Text("Customer ID: \(viewModel.customer.id)")
+                            Text(String(localized: .customerIdFormat(String(viewModel.customer.id))))
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -65,7 +65,10 @@ private struct CustomerOrdersSheetContentView: View {
                     HStack {
                         Image(systemName: "location.fill")
                             .foregroundStyle(.green)
-                        Text("Lat: \(viewModel.customer.latitude, specifier: "%.6f"), Lon: \(viewModel.customer.longitude, specifier: "%.6f")")
+                        Text(String(localized: .latitudeLongitudeFormat(
+                            String(format: "%.6f", viewModel.customer.latitude),
+                            String(format: "%.6f", viewModel.customer.longitude)
+                        )))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -117,9 +120,11 @@ private struct CustomerOrdersSheetContentView: View {
                 }
             }
             
-            ToolbarItem(placement: .topBarTrailing) {
-                Button("Done") {
+            ToolbarItem(placement: .confirmationAction) {
+                Button {
                     viewModel.dismissSheet()
+                } label: {
+                    Text(.done)
                 }
             }
         }

--- a/FloraList/FloraList/Navigation/AppTab.swift
+++ b/FloraList/FloraList/Navigation/AppTab.swift
@@ -12,11 +12,11 @@ enum AppTab: Hashable {
     case map
     case settings
 
-    var title: String {
+    var title: LocalizedStringResource {
         switch self {
-        case .orders: "Orders"
-        case .map: "Map"
-        case .settings: "Settings"
+        case .orders: .orders
+        case .map: .map
+        case .settings: .settings
         }
     }
 

--- a/FloraList/FloraList/Navigation/MainTabView.swift
+++ b/FloraList/FloraList/Navigation/MainTabView.swift
@@ -15,19 +15,31 @@ struct MainTabView: View {
             OrdersListView()
                 .tag(AppTab.orders)
                 .tabItem {
-                    Label(AppTab.orders.title, systemImage: AppTab.orders.icon)
+                    Label {
+                        Text(AppTab.orders.title)
+                    } icon: {
+                        Image(systemName: AppTab.orders.icon)
+                    }
                 }
 
             CustomerMapView()
                 .tag(AppTab.map)
                 .tabItem {
-                    Label(AppTab.map.title, systemImage: AppTab.map.icon)
+                    Label {
+                        Text(AppTab.map.title)
+                    } icon: {
+                        Image(systemName: AppTab.map.icon)
+                    }
                 }
 
             SettingsView()
                 .tag(AppTab.settings)
                 .tabItem {
-                    Label(AppTab.settings.title, systemImage: AppTab.settings.icon)
+                    Label {
+                        Text(AppTab.settings.title)
+                    } icon: {
+                        Image(systemName: AppTab.settings.icon)
+                    }
                 }
         }
         .environment(\.selectedTab, $selectedTab)

--- a/FloraList/FloraList/Orders/OrderDetail/OrderDetailView.swift
+++ b/FloraList/FloraList/Orders/OrderDetail/OrderDetailView.swift
@@ -78,7 +78,7 @@ private struct OrderDetailContentView: View {
     }
 
     private var orderInfo: some View {
-        LabeledContent("Order #\(viewModel.order.id)") {
+        LabeledContent(String(localized: .orderIdFormat(String(viewModel.order.id)))) {
             Text("$\(viewModel.order.price, specifier: "%.2f")")
                 .font(.title3)
                 .fontWeight(.medium)
@@ -90,30 +90,40 @@ private struct OrderDetailContentView: View {
     }
 
     private var statusSection: some View {
-        Picker("Order Status", selection: .init(
+        Picker(selection: .init(
             get: { viewModel.order.status },
             set: { viewModel.updateStatus($0) }
-        )) {
+        ), content: {
             ForEach(OrderStatus.allCases, id: \.self) { status in
-                Label(status.displayName, systemImage: status.systemImage)
-                    .foregroundStyle(status.color)
-                    .tag(status)
+                Label {
+                    Text(status.displayName)
+                } icon: {
+                    Image(systemName: status.systemImage)
+                }
+                .foregroundStyle(status.color)
+                .tag(status)
             }
-        }
+        }, label: {
+            Text(.sortStatus)
+        })
         .pickerStyle(.menu)
     }
 
     private var customerInfoSection: some View {
         Section {
             HStack {
-                Text("Customer Information")
+                Text(.customerDetails)
                     .font(.headline)
                 Spacer()
             }
 
             if let customer = viewModel.customer {
                 VStack(alignment: .leading, spacing: 8) {
-                    Label(customer.name, systemImage: "person.fill")
+                    Label {
+                        Text(customer.name)
+                    } icon: {
+                        Image(systemName: "person.fill")
+                    }
 
                     LocationInfoLabel(customer: customer)
 
@@ -128,15 +138,19 @@ private struct OrderDetailContentView: View {
                         await viewModel.navigateToCustomerOnMap(customer)
                     }
                 } label: {
-                    Label("View on Map", systemImage: "map")
-                        .foregroundStyle(.blue)
-                        .fontWeight(.semibold)
-                        .frame(maxWidth: .infinity)
-                        .contentShape(.rect)
+                    Label {
+                        Text(.viewOnMap)
+                    } icon: {
+                        Image(systemName: "map")
+                    }
+                    .foregroundStyle(.blue)
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+                    .contentShape(.rect)
                 }
                 .buttonStyle(.plain)
             } else {
-                Text("Customer information unavailable")
+                Text(.customerInformationUnavailable)
                     .foregroundStyle(.secondary)
             }
         }

--- a/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
+++ b/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
@@ -62,8 +62,8 @@ private struct OrdersListContentView: View {
             }
         }
         .listStyle(.plain)
-        .navigationTitle("Orders")
-        .searchable(text: $viewModel.searchText, prompt: "Search orders...")
+        .navigationTitle(Text(.orders))
+        .searchable(text: $viewModel.searchText, prompt: Text(.searchOrders))
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 filterSortMenu
@@ -102,7 +102,7 @@ private struct OrdersListContentView: View {
             Spacer()
             VStack {
                 ProgressView()
-                Text("Loading orders...")
+                Text(.loadingOrders)
                     .foregroundStyle(.secondary)
             }
             Spacer()
@@ -167,7 +167,11 @@ private struct OrdersListContentView: View {
                 }
             }
         } label: {
-            Label("Filter by Status", systemImage: "tag")
+            Label {
+                Text(.filterByStatus)
+            } icon: {
+                Image(systemName: "tag")
+            }
         }
     }
 
@@ -178,7 +182,7 @@ private struct OrdersListContentView: View {
                     viewModel.selectedSortOption = viewModel.selectedSortOption == option ? nil : option
                 } label: {
                     HStack {
-                        Text(option.rawValue)
+                        Text(option.displayName)
                         Spacer()
                         if viewModel.selectedSortOption == option {
                             Image(systemName: "checkmark")

--- a/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
+++ b/FloraList/FloraList/Orders/OrdersList/OrdersListView.swift
@@ -113,12 +113,18 @@ private struct OrdersListContentView: View {
 
     private func errorView(_ message: String) -> some View {
         ContentUnavailableView {
-            Label("Unable to Load Orders", systemImage: "wifi.exclamationmark")
+            Label {
+                Text(.unableToLoadOrders)
+            } icon: {
+                Image(systemName: "wifi.exclamationmark")
+            }
         } description: {
             Text(message)
         } actions: {
-            Button("Try Again") {
+            Button {
                 Task { await viewModel.refresh() }
+            } label: {
+                Text(.tryAgain)
             }
             .buttonStyle(.borderedProminent)
         }
@@ -141,12 +147,20 @@ private struct OrdersListContentView: View {
                 Button(role: .destructive) {
                     viewModel.clearFilters()
                 } label: {
-                    Label("Clear All", systemImage: "xmark.circle.fill")
+                    Label {
+                        Text(.clearAll)
+                    } icon: {
+                        Image(systemName: "xmark.circle.fill")
+                    }
                 }
             }
         } label: {
-            Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
-                .symbolVariant(hasActiveFilters ? .fill : .none)
+            Label {
+                Text(.filter)
+            } icon: {
+                Image(systemName: "line.3.horizontal.decrease.circle")
+                    .symbolVariant(hasActiveFilters ? .fill : .none)
+            }
         }
     }
 
@@ -191,7 +205,11 @@ private struct OrdersListContentView: View {
                 }
             }
         } label: {
-            Label("Sort Orders", systemImage: "arrow.up.arrow.down")
+            Label {
+                Text(.sortOrders)
+            } icon: {
+                Image(systemName: "arrow.up.arrow.down")
+            }
         }
     }
 }

--- a/FloraList/FloraList/Orders/OrdersList/OrdersListViewModel.swift
+++ b/FloraList/FloraList/Orders/OrdersList/OrdersListViewModel.swift
@@ -16,9 +16,20 @@ final class OrdersListViewModel {
     var selectedStatus: OrderStatus?
 
     enum SortOption: String, CaseIterable {
-        case priceHighToLow = "Price: High to Low"
-        case priceLowToHigh = "Price: Low to High"
-        case status = "Status"
+        case priceHighToLow = "sort_price_high_to_low"
+        case priceLowToHigh = "sort_price_low_to_high"
+        case status = "sort_status"
+        
+        var displayName: String {
+            switch self {
+            case .priceHighToLow:
+                return String(localized: .sortPriceHighToLow)
+            case .priceLowToHigh:
+                return String(localized: .sortPriceLowToHigh)
+            case .status:
+                return String(localized: .sortStatus)
+            }
+        }
     }
 
     var selectedSortOption: SortOption?

--- a/FloraList/FloraList/Settings/SettingsView.swift
+++ b/FloraList/FloraList/Settings/SettingsView.swift
@@ -15,7 +15,7 @@ struct SettingsView: View {
     @Environment(OrderManager.self) private var orderManager
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             SettingsContentView(
                 viewModel: SettingsViewModel(
                     locationManager: locationManager,
@@ -41,45 +41,69 @@ private struct SettingsContentView: View {
                     locationRow
                     notificationRow
                 } header: {
-                    Text("Permissions")
+                    Text(.permissions)
                 } footer: {
-                    Text("Tap any permission to change it in Settings.")
+                    Text(.permissionsDescription)
+                }
+                
+                Section {
+                    languagePicker
+                } header: {
+                    Text(.language)
+                } footer: {
+                    Text(.languageDescription)
                 }
                 
                 Section {
                     networkingRow
                 } header: {
-                    Text("Developer")
+                    Text(.developer)
                 } footer: {
-                    Text("Switch between REST and GraphQL networking implementations.")
+                    Text(.developerSettingsDescription)
                 }
                 
-                Section("About") {
+                Section {
                     HStack {
-                        Text("Version")
+                        Text(.version)
                         Spacer()
                         Text(viewModel.appVersion)
                             .foregroundStyle(.secondary)
                     }
+                } header: {
+                    Text(.about)
                 }
             }
-            .navigationTitle("Settings")
+            .listSectionSpacing(16)
+            .contentMargins(.top, 16, for: .scrollContent)
+            .navigationTitle(Text(.settings))
             .onAppear {
                 viewModel.onAppear()
             }
-            .alert("Location Permission", isPresented: $viewModel.showingLocationAlert) {
-                Button("Open Settings") {
+            .alert(Text(.locationPermission), isPresented: $viewModel.showingLocationAlert) {
+                Button {
                     viewModel.openAppSettings()
+                } label: {
+                    Text(.openSettings)
                 }
-                Button("Cancel", role: .cancel) { }
+                Button(role: .cancel) {
+                    // Do nothing
+                } label: {
+                    Text(.cancel)
+                }
             } message: {
                 Text(viewModel.locationAlertMessage)
             }
-            .alert("Notification Permission", isPresented: $viewModel.showingNotificationAlert) {
-                Button("Open Settings") {
+            .alert(Text(.notificationPermission), isPresented: $viewModel.showingNotificationAlert) {
+                Button {
                     viewModel.openAppSettings()
+                } label: {
+                    Text(.openSettings)
                 }
-                Button("Cancel", role: .cancel) { }
+                Button(role: .cancel) {
+                    // Do nothing
+                } label: {
+                    Text(.cancel)
+                }
             } message: {
                 Text(viewModel.notificationAlertMessage)
             }
@@ -97,9 +121,9 @@ private struct SettingsContentView: View {
                     .frame(width: 20)
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Location Services")
+                    Text(.locationServices)
                         .foregroundStyle(.primary)
-                    Text("Show distances and routes to customers")
+                    Text(.locationServicesDescription)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -136,9 +160,9 @@ private struct SettingsContentView: View {
                     .frame(width: 20)
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Notifications")
+                    Text(.notifications)
                         .foregroundStyle(.primary)
-                    Text("Get updates when order status changes")
+                    Text(.notificationsDescription)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -165,15 +189,41 @@ private struct SettingsContentView: View {
     }
 
     private var networkingRow: some View {
-        Picker("API Implementation", selection: Binding(
+        Picker(selection: Binding(
             get: { viewModel.currentNetworkingType },
             set: { newType in
                 viewModel.switchNetworkingType(to: newType)
             }
-        )) {
-            Text("REST").tag(NetworkingType.rest)
-            Text("GraphQL").tag(NetworkingType.graphQL)
-        }
+        ), content: {
+            Text(.rest).tag(NetworkingType.rest)
+            Text(.graphql).tag(NetworkingType.graphQL)
+        }, label: {
+            Text(.apiImplementation)
+        })
+        .pickerStyle(.menu)
+    }
+    
+    private var languagePicker: some View {
+        Picker(selection: Binding(
+            get: { LocalizationManager.shared.currentLanguage },
+            set: { newLanguage in
+                LocalizationManager.shared.setLanguage(newLanguage)
+            }
+        ), content: {
+            ForEach(LocalizationManager.SupportedLanguage.allCases, id: \.self) { language in
+                Group {
+                    Text(language.flag) + Text(language.displayName)
+                }
+                .tag(language)
+            }
+        }, label: {
+            HStack {
+                Image(systemName: "globe")
+                    .foregroundColor(.purple)
+                    .frame(width: 20)
+                Text(.language)
+            }
+        })
         .pickerStyle(.menu)
     }
 }
@@ -184,4 +234,5 @@ private struct SettingsContentView: View {
         .environment(NotificationManager())
         .environment(AnalyticsManager.shared)
         .environment(OrderManager(notificationManager: NotificationManager()))
+
 }

--- a/FloraList/FloraList/Settings/SettingsViewModel.swift
+++ b/FloraList/FloraList/Settings/SettingsViewModel.swift
@@ -15,20 +15,25 @@ class SettingsViewModel {
     private let notificationManager: NotificationManager
     private let analyticsManager: AnalyticsManager
     private let orderManager: OrderManager
+    private let localizationManager: LocalizationManager
 
     var showingLocationAlert = false
     var showingNotificationAlert = false
+    var currentLanguage: LocalizationManager.SupportedLanguage {
+        get { localizationManager.currentLanguage }
+        set { localizationManager.setLanguage(newValue) }
+    }
 
     var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
     }
     
-    var networkingTypeText: String {
+    var networkingTypeText: LocalizedStringResource {
         switch orderManager.networkingType {
         case .rest:
-            return "REST"
+            return .rest
         case .graphQL:
-            return "GraphQL"
+            return .graphql
         }
     }
     
@@ -44,12 +49,12 @@ class SettingsViewModel {
         orderManager.networkingType
     }
     
-    var locationStatusText: String {
-        isLocationEnabled ? "Enabled" : "Disabled"
+    var locationStatusText: LocalizedStringResource {
+        isLocationEnabled ? .enabled : .disabled
     }
     
-    var notificationStatusText: String {
-        isNotificationEnabled ? "Enabled" : "Disabled"
+    var notificationStatusText: LocalizedStringResource {
+        isNotificationEnabled ? .enabled : .disabled
     }
     
     var locationAlertMessage: String {
@@ -64,12 +69,14 @@ class SettingsViewModel {
         locationManager: LocationManager,
         notificationManager: NotificationManager,
         analyticsManager: AnalyticsManager,
-        orderManager: OrderManager
+        orderManager: OrderManager,
+        localizationManager: LocalizationManager = .shared
     ) {
         self.locationManager = locationManager
         self.notificationManager = notificationManager
         self.analyticsManager = analyticsManager
         self.orderManager = orderManager
+        self.localizationManager = localizationManager
     }
     
     // MARK: - Methods

--- a/FloraList/FloraList/Shared/Components/Labels/LocationInfoLabel.swift
+++ b/FloraList/FloraList/Shared/Components/Labels/LocationInfoLabel.swift
@@ -26,7 +26,7 @@ struct LocationInfoLabel: View {
     private var coordinateText: String {
         let latitude = String(format: "%.6f", customer.latitude)
         let longitude = String(format: "%.6f", customer.longitude)
-        return "Lat: \(latitude), Lon: \(longitude)"
+        return String(localized: .latitudeLongitudeFormat(latitude, longitude))
     }
 }
 

--- a/FloraList/FloraList/Shared/Components/Labels/RouteInfoLabel.swift
+++ b/FloraList/FloraList/Shared/Components/Labels/RouteInfoLabel.swift
@@ -15,7 +15,7 @@ struct RouteInfoLabel: View {
     var iconColor: Color = .orange
     var font: Font = .caption
 
-    @State private var distance: String = "Calculating..."
+    @State private var distance: String = String(localized: .calculatingDistance)
 
     var body: some View {
         if locationManager.isLocationAvailable {
@@ -38,7 +38,7 @@ struct RouteInfoLabel: View {
             }
         } else {
             Label {
-                Text("Enable location for distance")
+                Text(.enableLocationForDistance)
                     .font(font)
                     .foregroundStyle(.secondary)
             } icon: {

--- a/FloraList/FloraList/Shared/Extensions/LocalizedStringResource+Extensions.swift
+++ b/FloraList/FloraList/Shared/Extensions/LocalizedStringResource+Extensions.swift
@@ -70,6 +70,7 @@ extension LocalizedStringResource {
     static let enableLocationForDistance = LocalizedStringResource("enable_location_for_distance")
     static let customerInformationUnavailable = LocalizedStringResource("customer_information_unavailable")
     static let noOrdersYet = LocalizedStringResource("no_orders_yet")
+    static let customerNoOrdersMessage = LocalizedStringResource("customer_no_orders_message")
 
     // MARK: - Notifications Content
     static let orderStatusUpdated = LocalizedStringResource("order_status_updated")
@@ -91,9 +92,14 @@ extension LocalizedStringResource {
         LocalizedStringResource("order_status_updated_body", defaultValue: "Order #\(orderId) (\(description)) is now \(status)")
     }
     
+    static func ordersWithCount(_ count: Int) -> LocalizedStringResource {
+        LocalizedStringResource("orders_with_count", defaultValue: "Orders (\(count))")
+    }
+    
     // MARK: - Language Settings
     static let language = LocalizedStringResource("language", comment: "Language settings section header")
     static let languageDescription = LocalizedStringResource("language_description", comment: "Language settings description")
     static let english = LocalizedStringResource("english", comment: "English language option")
     static let spanish = LocalizedStringResource("spanish", comment: "Spanish language option")
+    static let german = LocalizedStringResource("german", comment: "German language option")
 } 

--- a/FloraList/FloraList/Shared/Extensions/LocalizedStringResource+Extensions.swift
+++ b/FloraList/FloraList/Shared/Extensions/LocalizedStringResource+Extensions.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+extension LocalizedStringResource {
+
+    // MARK: - Navigation & Tabs
+    static let orders = LocalizedStringResource("orders")
+    static let map = LocalizedStringResource("map")
+    static let settings = LocalizedStringResource("settings")
+    static let customerLocations = LocalizedStringResource("customer_locations")
+    static let customerDetails = LocalizedStringResource("customer_details")
+    
+    // MARK: - Common Actions
+    static let cancel = LocalizedStringResource("cancel")
+    static let tryAgain = LocalizedStringResource("try_again")
+    static let openSettings = LocalizedStringResource("open_settings")
+    static let clearAll = LocalizedStringResource("clear_all")
+    static let filter = LocalizedStringResource("filter")
+    static let done = LocalizedStringResource("done")
+    static let viewOnMap = LocalizedStringResource("view_on_map")
+    static let ok = LocalizedStringResource("ok")
+    static let deepLinkError = LocalizedStringResource("deep_link_error")
+    
+    // MARK: - Settings
+    static let permissions = LocalizedStringResource("permissions")
+    static let permissionsDescription = LocalizedStringResource("permissions_description")
+    static let developer = LocalizedStringResource("developer")
+    static let developerSettingsDescription = LocalizedStringResource("developer_settings_description")
+    static let about = LocalizedStringResource("about")
+    static let version = LocalizedStringResource("version")
+    
+    // MARK: - Location Services
+    static let locationServices = LocalizedStringResource("location_services")
+    static let locationServicesDescription = LocalizedStringResource("location_services_description")
+    static let locationPermission = LocalizedStringResource("location_permission")
+    static let enabled = LocalizedStringResource("enabled")
+    static let disabled = LocalizedStringResource("disabled")
+    
+    // MARK: - Notifications
+    static let notifications = LocalizedStringResource("notifications")
+    static let notificationsDescription = LocalizedStringResource("notifications_description")
+    static let notificationPermission = LocalizedStringResource("notification_permission")
+    
+    // MARK: - API Implementation
+    static let apiImplementation = LocalizedStringResource("api_implementation")
+    static let rest = LocalizedStringResource("rest")
+    static let graphql = LocalizedStringResource("graphql")
+    
+    // MARK: - Order Status
+    static let orderStatusNew = LocalizedStringResource("order_status_new")
+    static let orderStatusPending = LocalizedStringResource("order_status_pending")
+    static let orderStatusDelivered = LocalizedStringResource("order_status_delivered")
+    
+    // MARK: - Sorting & Filtering
+    static let sortOrders = LocalizedStringResource("sort_orders")
+    static let filterByStatus = LocalizedStringResource("filter_by_status")
+    static let sortPriceHighToLow = LocalizedStringResource("sort_price_high_to_low")
+    static let sortPriceLowToHigh = LocalizedStringResource("sort_price_low_to_high")
+    static let sortStatus = LocalizedStringResource("sort_status")
+    
+    // MARK: - Search & Loading
+    static let searchOrders = LocalizedStringResource("search_orders")
+    static let loadingOrders = LocalizedStringResource("loading_orders")
+    static let loadingCustomerLocations = LocalizedStringResource("loading_customer_locations")
+    static let calculatingDistance = LocalizedStringResource("calculating_distance")
+    
+    // MARK: - Error Messages
+    static let unableToLoadOrders = LocalizedStringResource("unable_to_load_orders")
+    static let unableToLoadLocations = LocalizedStringResource("unable_to_load_locations")
+    static let distanceUnavailable = LocalizedStringResource("distance_unavailable")
+    static let enableLocationForDistance = LocalizedStringResource("enable_location_for_distance")
+    static let customerInformationUnavailable = LocalizedStringResource("customer_information_unavailable")
+    static let noOrdersYet = LocalizedStringResource("no_orders_yet")
+
+    // MARK: - Notifications Content
+    static let orderStatusUpdated = LocalizedStringResource("order_status_updated")
+    
+    // MARK: - Interpolation Methods
+    static func orderIdFormat(_ id: String) -> LocalizedStringResource {
+        LocalizedStringResource("order_id_format", defaultValue: "Order #\(id)")
+    }
+    
+    static func customerIdFormat(_ id: String) -> LocalizedStringResource {
+        LocalizedStringResource("customer_id_format", defaultValue: "Customer ID: \(id)")
+    }
+    
+    static func latitudeLongitudeFormat(_ latitude: String, _ longitude: String) -> LocalizedStringResource {
+        LocalizedStringResource("latitude_longitude_format", defaultValue: "Lat: \(latitude), Lon: \(longitude)")
+    }
+  
+    static func orderStatusUpdatedBody(_ orderId: String, _ description: String, _ status: String) -> LocalizedStringResource {
+        LocalizedStringResource("order_status_updated_body", defaultValue: "Order #\(orderId) (\(description)) is now \(status)")
+    }
+    
+    // MARK: - Language Settings
+    static let language = LocalizedStringResource("language", comment: "Language settings section header")
+    static let languageDescription = LocalizedStringResource("language_description", comment: "Language settings description")
+    static let english = LocalizedStringResource("english", comment: "English language option")
+    static let spanish = LocalizedStringResource("spanish", comment: "Spanish language option")
+} 

--- a/FloraList/FloraList/Shared/Managers/LocalizationManager.swift
+++ b/FloraList/FloraList/Shared/Managers/LocalizationManager.swift
@@ -1,0 +1,61 @@
+//
+//  LocalizationManager.swift
+//  FloraList
+//
+//  Created by User on 6/17/25.
+//
+
+import Foundation
+import SwiftUI
+
+@Observable
+final class LocalizationManager {
+    static let shared = LocalizationManager()
+    
+    private static let languageKey = "FloraListAppLanguage"
+
+    enum SupportedLanguage: String, CaseIterable {
+        case english = "en"
+        case spanish = "es"
+
+        var displayName: LocalizedStringResource {
+            switch self {
+            case .english: return .english
+            case .spanish: return .spanish
+            }
+        }
+
+        var flag: String {
+            switch self {
+            case .english: return "🇺🇸"
+            case .spanish: return "🇪🇸"
+            }
+        }
+        
+        var locale: Locale {
+            Locale(identifier: rawValue)
+        }
+    }
+
+    private(set) var currentLanguage: SupportedLanguage
+
+    private init() {
+        self.currentLanguage = Self.loadSavedLanguage()
+    }
+    
+    private static func loadSavedLanguage() -> SupportedLanguage {
+        if let systemLanguages = UserDefaults.standard.array(forKey: languageKey) as? [String],
+           let firstLanguage = systemLanguages.first,
+           let language = SupportedLanguage(rawValue: firstLanguage) {
+            return language
+        }
+        
+        let systemLanguageCode = Locale.current.language.languageCode?.identifier ?? "en"
+        return SupportedLanguage(rawValue: systemLanguageCode) ?? .english
+    }
+
+    func setLanguage(_ language: SupportedLanguage) {
+        currentLanguage = language
+        UserDefaults.standard.set([language.rawValue], forKey: Self.languageKey)
+    }
+}

--- a/FloraList/FloraList/Shared/Managers/LocalizationManager.swift
+++ b/FloraList/FloraList/Shared/Managers/LocalizationManager.swift
@@ -17,11 +17,13 @@ final class LocalizationManager {
     enum SupportedLanguage: String, CaseIterable {
         case english = "en"
         case spanish = "es"
+        case german = "de"
 
         var displayName: LocalizedStringResource {
             switch self {
             case .english: return .english
             case .spanish: return .spanish
+            case .german: return .german
             }
         }
 
@@ -29,6 +31,7 @@ final class LocalizationManager {
             switch self {
             case .english: return "🇺🇸"
             case .spanish: return "🇪🇸"
+            case .german: return "🇩🇪"
             }
         }
         

--- a/FloraList/FloraListWidget/Extensions/LocalizedStringResource+Extensions.swift
+++ b/FloraList/FloraListWidget/Extensions/LocalizedStringResource+Extensions.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension LocalizedStringResource {
+
+    // MARK: - Widget Content
+    static let revenue = LocalizedStringResource("revenue")
+    static let totalOrders = LocalizedStringResource("total_orders")
+    
+    // MARK: - Interpolation Methods
+    static func revenueNextFormat(_ next: String) -> LocalizedStringResource {
+        LocalizedStringResource("revenue_next_format", defaultValue: "Next: \(next)")
+    }
+} 

--- a/FloraList/FloraListWidget/Localizable.xcstrings
+++ b/FloraList/FloraListWidget/Localizable.xcstrings
@@ -1,0 +1,72 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "%lld" : {
+
+    },
+    "$%.0f" : {
+
+    },
+    "FloraList" : {
+      "shouldTranslate" : false
+    },
+    "FloraList Orders" : {
+
+    },
+    "revenue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revenue"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresos"
+          }
+        }
+      }
+    },
+    "revenue_next_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siguiente: %@"
+          }
+        }
+      }
+    },
+    "Stay updated on your pending flower deliveries." : {
+
+    },
+    "total_orders" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total Orders"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pedidos Totales"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/FloraList/FloraListWidget/Localizable.xcstrings
+++ b/FloraList/FloraListWidget/Localizable.xcstrings
@@ -13,6 +13,52 @@
     "FloraList Orders" : {
 
     },
+    "new_orders" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nuevos"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neu"
+          }
+        }
+      }
+    },
+    "pending_orders" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pending"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendientes"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ausstehend"
+          }
+        }
+      }
+    },
     "revenue" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -26,6 +72,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingresos"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umsatz"
           }
         }
       }
@@ -43,6 +95,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Siguiente: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nächste: %@"
           }
         }
       }
@@ -63,6 +121,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pedidos Totales"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesamtbestellungen"
           }
         }
       }

--- a/FloraList/FloraListWidget/Views/MediumWidgetView.swift
+++ b/FloraList/FloraListWidget/Views/MediumWidgetView.swift
@@ -57,7 +57,7 @@ struct MediumWidgetView: View {
             Text("\(entry.totalOrders)")
                 .font(.title)
                 .fontWeight(.bold)
-            Text("Total Orders")
+            Text(.totalOrders)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
         }
@@ -65,9 +65,9 @@ struct MediumWidgetView: View {
     
     private var statusLabelsView: some View {
         HStack {
-            Label("\(entry.newOrders) New".uppercased(), systemImage: "plus.circle.fill")
+            Label("\(entry.newOrders)", systemImage: "plus.circle.fill")
                 .foregroundStyle(.blue)
-            Label("\(entry.pendingOrders) Pending".uppercased(), systemImage: "clock.fill")
+            Label("\(entry.pendingOrders)", systemImage: "clock.fill")
                 .foregroundStyle(.orange)
         }
         .font(.caption)
@@ -87,14 +87,14 @@ struct MediumWidgetView: View {
                 .font(.title)
                 .fontWeight(.bold)
                 .foregroundStyle(.green)
-            Text("Revenue")
+            Text(.revenue)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
         }
     }
     
     private var nextDeliveryView: some View {
-        Text("Next: \(entry.nextDelivery)")
+        Text(String(localized: .revenueNextFormat(entry.nextDelivery)))
             .font(.caption)
             .fontWeight(.medium)
             .foregroundStyle(.secondary)

--- a/FloraList/FloraListWidget/Views/SmallWidgetView.swift
+++ b/FloraList/FloraListWidget/Views/SmallWidgetView.swift
@@ -46,7 +46,7 @@ struct SmallWidgetView: View {
             Text("\(entry.totalOrders)")
                 .font(.title)
                 .fontWeight(.bold)
-            Text("Total Orders")
+            Text(.totalOrders)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
         }
@@ -64,7 +64,7 @@ struct SmallWidgetView: View {
     }
 
     private var nextDeliverySection: some View {
-        Text("Next: \(entry.nextDelivery)")
+        Text(String(localized: .revenueNextFormat(entry.nextDelivery)))
             .font(.caption)
             .fontWeight(.medium)
             .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
Add localization support using String Catalog (.xcstrings) format with support for English, Spanish, and German languages. Added runtime language switching capabilities and migrated all hardcoded strings to use LocalizedStringResource.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Configuration/Setup

## Changes Made
- Add Localizable.xcstrings files for main app and widget using String Catalog format
- Implement LocalizationManager with runtime language switching via UserDefaults
- Convert all hardcoded strings to LocalizedStringResource for modern iOS localization
- Add language picker in Settings with flag icons and language names
- Support for English, Spanish, and German languages with 100% translation coverage
- Add localized string extensions for complex formatting (order IDs, currency, etc.)

## Testing
- [x] Code compiles without warnings
- [x] Manual testing completed
- [x] No regressions in existing functionality

## UI Testing (if applicable)
- [x] Tested on different screen sizes (iPhone SE, Pro, Pro Max)
- [x] Works in both portrait and landscape
- [x] Dark/Light mode compatible
- [x] Accessibility considerations addressed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Context
<!-- Any decisions made, trade-offs, or future considerations --> 
